### PR TITLE
Strip shorter prefix in scabot

### DIFF
--- a/templates/default/scabot.conf.erb
+++ b/templates/default/scabot.conf.erb
@@ -1,7 +1,7 @@
 scala: {
   jenkins: {
     job:   "scala-2.11.x-validate-main"
-    jobPrefix: "scala-2.11.x-validate-" // this will be stripped when reporting to github
+    jobPrefix: "scala-2.11.x-" // this will be stripped when reporting to github TODO: remove once it's computed as s"${github.repo}-${pull.base.ref}-"
     host:  "scala-ci.typesafe.com"
     user:  "<%=node['scabot']['jenkins']['user']%>"
     token: "<%=node['scabot']['jenkins']['token']%>"


### PR DESCRIPTION
To deal with mix of scala-2.11.x-integrate-\* and
scala-2.11.x-validate-\* jobs.
