### PR TITLE
Release 2.10

### DIFF
--- a/recipes/_worker-config-debian.rb
+++ b/recipes/_worker-config-debian.rb
@@ -62,8 +62,10 @@ node["jenkinsHomes"].each do |jenkinsHome, workerConfig|
       "#{jenkinsHome}/.m2/settings.xml"          => "m2-settings.xml.erb" # TODO: remove pr-scala stuff, use different credentials for private-repo for PR validation and temp release artifacts
     }.each do |target, templ|
       template target do
-        source templ
-        user jenkinsUser
+        source    templ
+        user      jenkinsUser
+        owner     jenkinsUser
+        mode      '600'
         sensitive true
 
         variables({

--- a/recipes/_worker-config-debian.rb
+++ b/recipes/_worker-config-debian.rb
@@ -59,6 +59,7 @@ node["jenkinsHomes"].each do |jenkinsHome, workerConfig|
       "#{jenkinsHome}/.credentials"              => "credentials-sonatype.erb", # TODO: remove after replacing references to it in scripts by `.credentials-sonatype`
       "#{jenkinsHome}/.sonatype-curl"            => "sonatype-curl.erb",
       "#{jenkinsHome}/.s3credentials"            => "s3credentials.erb",
+      "#{jenkinsHome}/.s3curl"                   => "s3curl.erb",
       "#{jenkinsHome}/.m2/settings.xml"          => "m2-settings.xml.erb" # TODO: remove pr-scala stuff, use different credentials for private-repo for PR validation and temp release artifacts
     }.each do |target, templ|
       template target do

--- a/recipes/_worker-init-debian.rb
+++ b/recipes/_worker-init-debian.rb
@@ -9,7 +9,7 @@
 
 include_recipe "apt" # do apt-get update
 
-%w{openjdk-7-jdk openjdk-8-jdk ant ant-contrib ant-optional maven}.each do |pkg|
+%w{openjdk-7-jdk openjdk-8-jdk ant ant-contrib ant-optional maven s3curl}.each do |pkg|
   package pkg
 end
 


### PR DESCRIPTION
To fit in the release 2.10 scripts into the new flow, we need to store the scala-dist tarball on s3. Separate PR coming for scala/scala#2.10.x's scripts/jobs/integrate/bootstrap as well as scala/scala-dist.
