### PR TITLE
Centralize strings in prep of private-repo move.

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -21,8 +21,16 @@ default['master']['github']['allowCcTrayPermission']                = 'false'
 default['master']['github']['authenticatedUserCreateJobPermission'] = 'false'
 
 default['master']['adminAddress'] = "adriaan@typesafe.com"
+default['master']['jenkinsHost']  = "scala-ci.typesafe.com" # duplicated because attributes can't refer to each other...
 default['master']['jenkinsUrl']   = "https://scala-ci.typesafe.com/"
 default['master']['jenkins']['notifyUrl'] = "http://scala-ci.typesafe.com:8888/jenkins"
+
+default['repos']['private']['realm']        = "Artifactory Realm"
+default['repos']['private']['host']         = "private-repo.typesafe.com"
+default['repos']['private']['pr-snap']      = "http://private-repo.typesafe.com/typesafe/scala-pr-validation-snapshots/",
+default['repos']['private']['release-temp'] = "http://private-repo.typesafe.com/typesafe/scala-release-temp/"
+
+default['s3']['downloads']['host'] = "downloads.typesafe.com.s3.amazonaws.com"
 
 default['master']['env'] = <<-'EOH'.gsub(/^ {2}/, '')
   lambda{| node | Chef::Node::ImmutableMash.new({

--- a/recipes/_master-config-workers.rb
+++ b/recipes/_master-config-workers.rb
@@ -38,7 +38,7 @@ search(:node, 'name:jenkins-worker*').each do |worker|
 
       # TODO: make retrying more robust
       max_num_retries  10  # how often to retry when the SSH connection is refused during initial connect
-      retry_wait_time  60 # seconds between retries
+      retry_wait_time  60  # seconds between retries
 
       remote_fs   jenkinsHome.dup
       jvm_options workerConfig["jvm_options"]
@@ -54,7 +54,7 @@ search(:node, 'name:jenkins-worker*').each do |worker|
       in_demand_delay workerConfig["in_demand_delay"]
       idle_delay      workerConfig["idle_delay"]
 
-      environment((eval node["master"]["env"]).call(node).merge((eval workerConfig["env"]).call(worker)))
+      environment((eval node["master"]["env"]).call(worker).merge((eval workerConfig["env"]).call(worker)))
 
       action [:create] # we don't need to :connect, :online since the ec2 start/stop plugin will do that. Also, if connect fails, it may be that chef-client hasn't yet run on the client to initialize jenkins home with .ssh/authorized_keys
     end

--- a/templates/default/credentials-private-repo.erb
+++ b/templates/default/credentials-private-repo.erb
@@ -1,4 +1,4 @@
-realm=Artifactory Realm
-host=private-repo.typesafe.com
+realm=<%=node['repos']['private']['realm']%>
+host=<%=node['repos']['private']['host']%>
 user=<%= @privateRepoUser %>
 password=<%= @privateRepoPass %>

--- a/templates/default/m2-settings-public-jobs.xml.erb
+++ b/templates/default/m2-settings-public-jobs.xml.erb
@@ -21,12 +21,12 @@
         <repository>
           <id>pr-scala</id>
           <name>Scala PR validation snapshots</name>
-          <url>http://private-repo.typesafe.com/typesafe/scala-pr-validation-snapshots</url>
+          <url><%=node['repos']['private']['pr-snap']%></url>
         </repository>
         <repository>
           <id>scala-release-temp</id>
           <name>Scala Relese snapshots</name>
-          <url>http://private-repo.typesafe.com/typesafe/scala-release-temp/</url>
+          <url><%=node['repos']['private']['release-temp']%></url>
         </repository>
       </repositories>
     </profile>

--- a/templates/default/nginx-jenkins.conf
+++ b/templates/default/nginx-jenkins.conf
@@ -13,7 +13,7 @@ server {
 # based on https://gist.github.com/plentz/6737338, among others
 server {
   listen 443 ssl default deferred;
-  server_name scala-ci.typesafe.com;
+  server_name <%=node['master']['jenkinsHost']%>;
 
   ssl on;
   ssl_certificate /etc/nginx/ssl/scala-ci.crt;

--- a/templates/default/s3credentials.erb
+++ b/templates/default/s3credentials.erb
@@ -1,4 +1,4 @@
 realm=Amazon S3
-host=downloads.typesafe.com.s3.amazonaws.com
-user=<%= @s3DownloadsUser %>
-password=<%= @s3DownloadsPass %>
+host=<%=node['s3']['downloads']['host']%>
+user=<%=@s3DownloadsUser%>
+password=<%=@s3DownloadsPass%>

--- a/templates/default/scabot.conf.erb
+++ b/templates/default/scabot.conf.erb
@@ -2,7 +2,7 @@ scala: {
   jenkins: {
     job:   "scala-2.11.x-validate-main"
     jobPrefix: "scala-2.11.x-" // this will be stripped when reporting to github TODO: remove once it's computed as s"${github.repo}-${pull.base.ref}-"
-    host:  "scala-ci.typesafe.com"
+    host:  "<%=node['master']['jenkinsHost']%>"
     user:  "<%=node['scabot']['jenkins']['user']%>"
     token: "<%=node['scabot']['jenkins']['token']%>"
   }


### PR DESCRIPTION
All repo url strings are now attributes. Will also need to change some occurrences over in scala/scala:

```
README.md:100:> set resolvers += "pr" at "http://private-repo.typesafe.com/typesafe/scala-pr-validation-snapshots/"
build.xml:474:    <property name="sbt.interface.url"     value="http://private-repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/interface/${sbt.latest.version}/jars/interface.jar"/>
build.xml:476:    <property name="sbt.interface.src.url" value="http://private-repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/compiler-interface/${sbt.latest.version}/jars/compiler-interface-src.jar"/>
scripts/jobs/integrate/bootstrap:21:# - ~/.credentials-private-repo for private-repo.typesafe.com, as follows:
scripts/jobs/integrate/bootstrap:23:    # host=private-repo.typesafe.com
scripts/jobs/integrate/bootstrap:112:privateRepo="http://private-repo.typesafe.com/typesafe/scala-release-temp/"
scripts/repositories-scala-release:3:  private-repo: http://private-repo.typesafe.com/typesafe/scala-release-temp/
scripts/repositories-scala-release:4:  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
tools/binary-repo-lib.sh:5:remote_urlget="http://repo.typesafe.com/typesafe/scala-sha-bootstrap/org/scala-lang/bootstrap"
tools/binary-repo-lib.sh:6:remote_urlpush="http://private-repo.typesafe.com/typesafe/scala-sha-bootstrap/org/scala-lang/bootstrap"
```
