### PR TITLE
cleanup 

### DIFF
--- a/.chef/Vagrantfile
+++ b/.chef/Vagrantfile
@@ -1,12 +1,20 @@
 # TODO: this kind of works, but the cookbook won't run in virtual box:
-#  - (scatter-gather workaround)
 #  - chef-solo can't access the vault on the chef server (passwords etc)
-# to make this work, you need to populate a cookbooks/ directory next to this file,
-# as documented in the README.md (use knife)
+# vagrant box add utopic-daily https://cloud-images.ubuntu.com/vagrant/utopic/current/utopic-server-cloudimg-amd64-vagrant-disk1.box
+# vagrant init utopic-daily
+# vagrant up
+# centos: vagrant box add chef/centos-7.0
 Vagrant.configure("2") do |config|
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "utopic-daily"
   config.vm.provision :chef_solo do |chef|
+    chef.cookbooks_path = ["~/git/cookbooks"]
+    chef.node_name = "jenkins-master"
     chef.add_recipe("scala-jenkins-infra::master-init")
+    chef.add_recipe("scala-jenkins-infra::_master-config-proxy")
   end
-  config.vm.network :forwarded_port, guest: 80, host: 11180
+  config.vm.network "public_network"
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 4096
+    v.cpus = 2
+  end
 end

--- a/README.md
+++ b/README.md
@@ -163,29 +163,64 @@ Test if knife works correctly by running `knife cookbook list`.
 
 Obtain the organization validation key from Adriaan and put it to `.chef/config/$CHEF_ORG-validator.pem`. (Q: When is this key used exactly? https://docs.chef.io/chef_private_keys.html says it's when a new node runs `chef-client` for the first time.)
 
-## Get cookbooks
+## Clone scala-jenkins-infra cookbook and its dependencies
+
+I think you can safely ignore `ERROR: IOError: Cannot open or read **/metadata.rb!` in the below
 
 ```
-git init .chef/cookbooks
-cd .chef/cookbooks
+cd ~/git/cookbooks
+git init .
 g commit --allow-empty -m"Initial" 
+
+hub clone scala/scala-jenkins-infra
+cd scala-jenkins-infra
+ln -sh ~/git/cookbooks .chef/
+
+knife site install cron
+knife site install logrotate
+knife site install chef_handler
+knife site install windows
+knife site install chef-client
+knife site install aws
+knife site install delayed_evaluator
+knife site install ebs
+knife site install java
+knife site install apt
+knife site install packagecloud
+knife site install runit
+knife site install yum
+knife site install jenkins
+knife site install 7-zip
+knife site install ark
+knife site install artifactory
+knife site install build-essential
+knife site install dmg
+knife site install yum-epel
+knife site install git
+knife site install user
+knife site install partial_search
+knife site install ssh_known_hosts
+knife site install git_user
+knife site install chef-sbt
+knife site install sbt-extras
 ```
 
-- knife cookbook site install wix 1.0.2 # newer versions don't work for me; also installs windows
-- knife cookbook site install aws
-- knife cookbook site install git
-- knife cookbook site install git_user
-  - knife cookbook site install partial_search
- 
-- move to unreleased versions on github:
-  - knife cookbook github install opscode-cookbooks/windows    # fix nosuchmethoderror (#150)
-  - knife cookbook github install adriaanm/java/windows-jdk1.6 # jdk 1.6 installer barfs on re-install -- wipe its INSTALLDIR
-  - knife cookbook github install adriaanm/jenkins/fix305      # ssl fail on windows
-  - knife cookbook github install adriaanm/scala-jenkins-infra
-  - knife cookbook github install adriaanm/chef-sbt
-  - knife cookbook github install gildegoma/chef-sbt-extras
+### Switch to unreleased versions from github
+```
+//fixed: knife cookbook github install opscode-cookbooks/windows    # fix nosuchmethoderror (#150)
+//knife cookbook github install adriaanm/jenkins/fix305      # ssl fail on windows -- fix pending: https://github.com/opscode-cookbooks/jenkins/pull/313
+knife cookbook github install b-dean/jenkins/http_ca_fixes  # pending fix for above ^^^
 
-- knife cookbook upload --all
+knife cookbook github install adriaanm/java/windows-jdk1.6 # jdk 1.6 installer barfs on re-install -- wipe its INSTALLDIR
+knife cookbook github install adriaanm/chef-sbt
+knife cookbook github install gildegoma/chef-sbt-extras
+knife cookbook github install adriaanm/artifactory
+```
+
+### Upload cookbooks to chef server
+```
+knife cookbook upload --all
+```
 
 ## Cache installers locally
 - they are tricky to access, might disappear,...

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ aws iam create-instance-profile --instance-profile-name JenkinsMaster
 aws iam create-instance-profile --instance-profile-name JenkinsWorkerPublish
 aws iam create-instance-profile --instance-profile-name JenkinsWorker
 
-aws iam create-role --role-name jenkins-master         --assume-role-policy-document file:///Users/adriaan/git/scala-jenkins-infra/chef/ec2-role-trust-policy.json
-aws iam create-role --role-name jenkins-worker         --assume-role-policy-document file:///Users/adriaan/git/scala-jenkins-infra/chef/ec2-role-trust-policy.json
-aws iam create-role --role-name jenkins-worker-publish --assume-role-policy-document file:///Users/adriaan/git/scala-jenkins-infra/chef/ec2-role-trust-policy.json
+aws iam create-role --role-name jenkins-master         --assume-role-policy-document file://$PWD/chef/ec2-role-trust-policy.json
+aws iam create-role --role-name jenkins-worker         --assume-role-policy-document file://$PWD/chef/ec2-role-trust-policy.json
+aws iam create-role --role-name jenkins-worker-publish --assume-role-policy-document file://$PWD/chef/ec2-role-trust-policy.json
 
 aws iam add-role-to-instance-profile --instance-profile-name JenkinsMaster        --role-name jenkins-master
 aws iam add-role-to-instance-profile --instance-profile-name JenkinsWorker        --role-name jenkins-worker
@@ -115,21 +115,23 @@ aws iam add-role-to-instance-profile --instance-profile-name JenkinsWorkerPublis
 ```
 
 ### Attach policies to roles:
-
-```
-aws iam put-role-policy --role-name jenkins-master --policy-name jenkins-ec2-start-stop --policy-document file:///Users/adriaan/git/scala-jenkins-infra/chef/jenkins-ec2-start-stop.json
-aws iam put-role-policy --role-name jenkins-master --policy-name jenkins-dynamodb --policy-document file:///Users/adriaan/git/scala-jenkins-infra/chef/dynamodb.json
-
-// TODO: once https://github.com/sbt/sbt-s3/issues/14 is fixed, remove s3credentials from nodes and use IAM profile instead
-aws iam put-role-policy --role-name jenkins-worker-publish --policy-name jenkins-s3-upload --policy-document file:///Users/adriaan/git/scala-jenkins-infra/chef/jenkins-s3-upload.json
-
-aws iam put-role-policy --role-name jenkins-worker --policy-name jenkins-ebs-create-vol --policy-document file:///Users/adriaan/git/scala-jenkins-infra/chef/ebs-create-vol.json
-
-aws iam put-role-policy --role-name jenkins-worker-publish --policy-name jenkins-ebs-create-vol --policy-document file:///Users/adriaan/git/scala-jenkins-infra/chef/ebs-create-vol.json
-```
-
 NOTE: if you get syntax errors, check the policy doc URL
-pass JenkinsWorker as the iam profile to knife bootstrap
+
+```
+aws iam put-role-policy --role-name jenkins-master --policy-name jenkins-ec2-start-stop        --policy-document file://$PWD/chef/jenkins-ec2-start-stop.json
+aws iam put-role-policy --role-name jenkins-master --policy-name jenkins-dynamodb              --policy-document file://$PWD/chef/dynamodb.json
+aws iam put-role-policy --role-name jenkins-master --policy-name jenkins-ebs-create-vol        --policy-document file://$PWD/chef/ebs-create-vol.json
+```
+
+```
+aws iam put-role-policy --role-name jenkins-worker --policy-name jenkins-ebs-create-vol        --policy-document file://$PWD/chef/ebs-create-vol.json
+```
+
+TODO: once https://github.com/sbt/sbt-s3/issues/14 is fixed, remove s3credentials from nodes (use IAM profile below instead)
+```
+aws iam put-role-policy --role-name jenkins-worker-publish --policy-name jenkins-s3-upload      --policy-document file://$PWD/chef/jenkins-s3-upload.json
+aws iam put-role-policy --role-name jenkins-worker-publish --policy-name jenkins-ebs-create-vol --policy-document file://$PWD/chef/ebs-create-vol.json
+```
 
 
 ## Create an Elastic IP for each node
@@ -157,11 +159,11 @@ If your username on chef.io does not match the local username on your machine, y
 export CHEF_USER="[username]"
 ```
 
-You can then generate and download your private key on https://www.chef.io/account/password. Put it to `.chef/config/$CHEF_USER.pem`, then you can use knife without further config. See `.chef/knife.rb` for key locations.
+You can then generate and download your private key on https://www.chef.io/account/password. Put it to `$PWD/.chef/config/$CHEF_USER.pem`, then you can use knife without further config. See `$PWD/.chef/knife.rb` for key locations.
 
 Test if knife works correctly by running `knife cookbook list`.
 
-Obtain the organization validation key from Adriaan and put it to `.chef/config/$CHEF_ORG-validator.pem`. (Q: When is this key used exactly? https://docs.chef.io/chef_private_keys.html says it's when a new node runs `chef-client` for the first time.)
+Obtain the organization validation key from Adriaan and put it to `$PWD/.chef/config/$CHEF_ORG-validator.pem`. (Q: When is this key used exactly? https://docs.chef.io/chef_private_keys.html says it's when a new node runs `chef-client` for the first time.)
 
 ## Clone scala-jenkins-infra cookbook and its dependencies
 
@@ -174,7 +176,7 @@ g commit --allow-empty -m"Initial"
 
 hub clone scala/scala-jenkins-infra
 cd scala-jenkins-infra
-ln -sh ~/git/cookbooks .chef/
+ln -sh ~/git/cookbooks $PWD/.chef/
 
 knife site install cron
 knife site install logrotate
@@ -240,23 +242,23 @@ NOTE: the JSON must not have a field "id"!!!
 ### Chef user with keypair for jenkins cli access
 ```
 eval "$(chef shell-init zsh)" # use chef's ruby, which has the net/ssh gem
-ruby chef/keypair.rb > ~/Desktop/chef-secrets/config/keypair.json
-ruby chef/keypair.rb > ~/Desktop/chef-secrets/config/scabot-keypair.json
+ruby chef/keypair.rb > $PWD/.chef/keypair.json
+ruby chef/keypair.rb > $PWD/.chef/scabot-keypair.json
 
-# extract private key to ~/Desktop/chef-secrets/config/scabot.pem
+# extract private key to $PWD/.chef/scabot.pem
 
 knife vault create master scala-jenkins-keypair \
-  --json ~/Desktop/chef-secrets/config/keypair.json \
+  --json $PWD/.chef/keypair.json \
   --search 'name:jenkins*' \
   --admins adriaan
 
 knife vault create master scabot-keypair \
-  --json ~/Desktop/chef-secrets/config/scabot-keypair.json \
+  --json $PWD/.chef/scabot-keypair.json \
   --search 'name:jenkins-master' \
   --admins adriaan
 
 knife vault create master scabot \
-  --json ~/Desktop/chef-secrets/config/scabot.json \
+  --json $PWD/.chef/scabot.json \
   --search 'name:jenkins-master' \
   --admins adriaan
 
@@ -302,12 +304,12 @@ knife vault create worker-publish s3-downloads \
   --admins adriaan
 
 knife vault create worker-publish chara-keypair \
-  --json chara-keypair.json \
+  --json $PWD/.chef/config/chara-keypair.json \
   --search 'name:jenkins-worker-ubuntu-publish' \
   --admins adriaan
 
 knife vault create worker-publish gnupg \
-  --json /Users/adriaan/Desktop/chef-secrets/gnupg.json \
+  --json   $PWD/.chef/config/gnupg.json \
   --search 'name:jenkins-worker-ubuntu-publish' \
   --admins adriaan
 
@@ -336,28 +338,28 @@ Note that the IPs are stable by allocating elastic IPs and associating them to n
 ## ~/.ssh/config
 ```
 Host jenkins-worker-ubuntu-publish
-  IdentityFile ~/Desktop/chef-secrets/config/chef.pem
+  IdentityFile $PWD/.chef/config/chef.pem
   User ubuntu
 
 Host jenkins-worker-behemoth-1
-  IdentityFile ~/Desktop/chef-secrets/config/chef.pem
+  IdentityFile $PWD/.chef/config/chef.pem
   User ec2-user
 
 Host jenkins-worker-behemoth-2
-  IdentityFile ~/Desktop/chef-secrets/config/chef.pem
+  IdentityFile $PWD/.chef/config/chef.pem
   User ec2-user
 
 Host jenkins-master
-  IdentityFile ~/Desktop/chef-secrets/config/chef.pem
+  IdentityFile $PWD/.chef/config/chef.pem
   User ec2-user
 
 Host scabot
   HostName jenkins-master
-  IdentityFile ~/Desktop/chef-secrets/config/scabot.pem
+  IdentityFile $PWD/.chef/scabot.pem
   User scabot
 
 Host jenkins-worker-windows-publish
-  IdentityFile ~/Desktop/chef-secrets/jenkins-chef
+  IdentityFile $PWD/.chef/config/chef.pem
   User jenkins
 ```
 
@@ -398,7 +400,7 @@ knife ec2 server create -N jenkins-master \
    --region us-west-1 --flavor t2.small -I ami-4b6f650e \
    -G Master --ssh-user ec2-user \
    --iam-profile JenkinsMaster \
-   --identity-file .chef/config/chef.pem \
+   --identity-file $PWD/.chef/config/chef.pem \
    --run-list "scala-jenkins-infra::master-init"
 
 knife ec2 server create -N jenkins-worker-windows-publish \
@@ -410,7 +412,7 @@ knife ec2 server create -N jenkins-worker-windows-publish \
    --security-group-ids sg-1dec3d78                       \
    --subnet subnet-4bb3b80d --associate-eip 54.183.156.89 \
    --server-connect-attribute public_ip_address           \
-   --identity-file .chef/config/chef.pem                  \
+   --identity-file $PWD/.chef/config/chef.pem             \
    --run-list "scala-jenkins-infra::worker-init"
 
 
@@ -424,7 +426,7 @@ knife ec2 server create -N jenkins-worker-ubuntu-publish  \
    --security-group-ids sg-ecb06389                       \
    --subnet subnet-4bb3b80d --associate-eip 54.67.33.167  \
    --server-connect-attribute public_ip_address           \
-   --identity-file .chef/config/chef.pem                  \
+   --identity-file $PWD/.chef/config/chef.pem             \
    --run-list "scala-jenkins-infra::worker-init"
 
 echo NOTE: Make sure to first remove the ips in $behemothIp from your ~/.ssh/known_hosts. Also remove the corresponding worker from the chef server (can be only one with the same name).
@@ -439,7 +441,7 @@ do knife ec2 server create -N jenkins-worker-behemoth-$behemoth      \
    --security-group-ids sg-ecb06389                                  \
    --subnet subnet-4bb3b80d --associate-eip ${behemothIp[$behemoth]} \
    --server-connect-attribute public_ip_address                      \
-   --identity-file .chef/config/chef.pem                             \
+   --identity-file $PWD/.chef/config/chef.pem                        \
    --run-list "scala-jenkins-infra::worker-init"
 done
 
@@ -481,7 +483,7 @@ done
 
 - windows:
 ```
-PASS=$(aws ec2 get-password-data --instance-id i-f67c0a35 --priv-launch-key ~/Desktop/chef-secrets/config/chef.pem | jq .PasswordData | xargs echo)
+PASS=$(aws ec2 get-password-data --instance-id i-f67c0a35 --priv-launch-key $PWD/.chef/config/chef.pem | jq .PasswordData | xargs echo)
 knife winrm jenkins-worker-windows-publish chef-client -m -P $PASS
 ```
 
@@ -505,7 +507,7 @@ Workaround: make sure EC2 instance names are unique.
 
 http://blog.gravitystorm.co.uk/2013/09/13/using-vagrant-to-test-chef-cookbooks/:
 
-See `.chef/Vagrantfile` -- make sure you first populated `.chef/cookbooks/` using knife,
+See `$PWD/.chef/Vagrantfile` -- make sure you first populated `$PWD/.chef/cookbooks/` using knife,
 as [documented above](#get-cookbooks)
 
 ## If connections hang
@@ -541,7 +543,7 @@ $ openssl req -text -noout -in scala-ci.csr
 
 ## Retry bootstrap
 ```
-knife bootstrap -c .chef/knife.rb jenkins-worker-ubuntu-publish --ssh-user ubuntu --sudo -c .chef/knife.rb -N jenkins-worker-ubuntu-publish -r "scala-jenkins-infra::worker-init"
+knife bootstrap -c $PWD/.chef/knife.rb jenkins-worker-ubuntu-publish --ssh-user ubuntu --sudo -c $PWD/.chef/knife.rb -N jenkins-worker-ubuntu-publish -r "scala-jenkins-infra::worker-init"
 ```
 
 ## WinRM troubles?
@@ -549,7 +551,7 @@ If it appears stuck at "Waiting for remote response before bootstrap.", the user
 (check C:\Program Files\Amazon\Ec2ConfigService\Logs) we need to enable unencrypted authentication:
 
 ```
-aws ec2 get-password-data --instance-id $INST --priv-launch-key ~/git/scala-jenkins-infra/.chef/config/chef.pem
+aws ec2 get-password-data --instance-id $INST --priv-launch-key $PWD/.chef/config/chef.pem
 
 cord $IP, log in using password above and open a command line:
 

--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -1,59 +1,68 @@
-override['jenkins']['master']['install_method'] = 'war'
-override['jenkins']['master']['listen_address'] = '127.0.0.1' # external traffic must go through nginx
-override['jenkins']['master']['user']           = 'jenkins'
-override['jenkins']['master']['group']          = 'jenkins'
-override['jenkins']['master']['jvm_options']    = '-server -Xmx4G -XX:MaxPermSize=512M -XX:+HeapDumpOnOutOfMemoryError' # -Dfile.encoding=UTF-8
+scalaCiHost = "scala-ci.typesafe.com"
+scalaCiPort = 443
 
-# To pin the jenkins version, must also override override['jenkins']['master']['source'] !!!
-# override['jenkins']['master']['version']  = '1.555'
-# override['jenkins']['master']['source']   = "#{node['jenkins']['master']['mirror']}/war/#{node['jenkins']['master']['version']}/jenkins.war"
-# override['jenkins']['master']['checksum'] = '31f5c2a3f7e843f7051253d640f07f7c24df5e9ec271de21e92dac0d7ca19431'
-
-default['master']['github']['webUri']                               = 'https://github.com/'
-default['master']['github']['apiUri']                               = 'https://api.github.com'
-default['master']['github']['adminUserNames']                       = 'adriaanm,retronym,lrytz,chef,scala-jenkins'
-default['master']['github']['organizationNames']                    = 'scala'
-default['master']['github']['useRepositoryPermissions']             = 'true'
-default['master']['github']['allowAnonymousReadPermission']         = 'true'
-default['master']['github']['authenticatedUserReadPermission']      = 'true'
-default['master']['github']['allowGithubWebHookPermission']         = 'true'
-default['master']['github']['allowCcTrayPermission']                = 'false'
-default['master']['github']['authenticatedUserCreateJobPermission'] = 'false'
-
-default['master']['adminAddress'] = "adriaan@typesafe.com"
-default['master']['jenkinsHost']  = "scala-ci.typesafe.com" # duplicated because attributes can't refer to each other...
-default['master']['jenkinsUrl']   = "https://scala-ci.typesafe.com/"
-default['master']['jenkins']['notifyUrl'] = "http://scala-ci.typesafe.com:8888/jenkins"
-
+# JENKINS WORKER CONFIG
 default['repos']['private']['realm']        = "Artifactory Realm"
 default['repos']['private']['host']         = "private-repo.typesafe.com"
 default['repos']['private']['pr-snap']      = "http://private-repo.typesafe.com/typesafe/scala-pr-validation-snapshots/"
 default['repos']['private']['release-temp'] = "http://private-repo.typesafe.com/typesafe/scala-release-temp/"
-
 default['s3']['downloads']['host'] = "downloads.typesafe.com.s3.amazonaws.com"
 
-# see below (note that default['master']['env'] can only indirect through node -- workerJavaOpts is not in scope)
-workerJavaOpts = "-Dfile.encoding=UTF-8 -server -XX:+AggressiveOpts -XX:+UseParNewGC -Xmx2G -Xss1M -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=128M -Dpartest.threads=4"
-default['jenkinsEnv']['JAVA_OPTS']  = workerJavaOpts
-default['jenkinsEnv']['ANT_OPTS']   = workerJavaOpts
-default['jenkinsEnv']['MAVEN_OPTS'] = workerJavaOpts # doesn't technically need the -Dpartest one, but oh well
+if node.name == "jenkins-master"
+  # JENKINS
+  override['jenkins']['master']['install_method'] = 'war'
+  override['jenkins']['master']['listen_address'] = '127.0.0.1' # external traffic must go through nginx
+  override['jenkins']['master']['user']           = 'jenkins'
+  override['jenkins']['master']['group']          = 'jenkins'
+  override['jenkins']['master']['jvm_options']    = '-server -Xmx4G -XX:MaxPermSize=512M -XX:+HeapDumpOnOutOfMemoryError' # -Dfile.encoding=UTF-8
 
-# NOTE: This is a string that represents a closure that closes over the worker node for which it computes the environment.
-# (by convention -- see `environment((eval node["master"]["env"])...` in _master-config-workers
-# Since we can't marshall closures, while attributes need to be sent from master to workers, we must encode them as something that can be shipped...
-default['master']['env'] = <<-'EOH'.gsub(/^ {2}/, '')
-  lambda{| node | Chef::Node::ImmutableMash.new({
-    "JAVA_HOME"          => node['java']['java_home'], # we get the jre if we don't do this
-    "JAVA_OPTS"          => node['jenkinsEnv']['JAVA_OPTS'],
-    "ANT_OPTS"           => node['jenkinsEnv']['ANT_OPTS'],
-    "MAVEN_OPTS"         => node['jenkinsEnv']['MAVEN_OPTS'],
-    "prRepoUrl"          => node['repos']['private']['pr-snap'],
-    "releaseTempRepoUrl" => node['repos']['private']['release-temp']
-  })}
-  EOH
+  # To pin the jenkins version, must also override override['jenkins']['master']['source'] !!!
+  # override['jenkins']['master']['version']  = '1.555'
+  # override['jenkins']['master']['source']   = "#{node['jenkins']['master']['mirror']}/war/#{node['jenkins']['master']['version']}/jenkins.war"
+  # override['jenkins']['master']['checksum'] = '31f5c2a3f7e843f7051253d640f07f7c24df5e9ec271de21e92dac0d7ca19431'
 
-default['master']['ec2-start-stop']['url'] = 'https://dl.dropboxusercontent.com/u/12862572/ec2-start-stop.hpi'
+  ## GITHUB OAUTH
+  default['master']['github']['webUri']                               = 'https://github.com/'
+  default['master']['github']['apiUri']                               = 'https://api.github.com'
+  default['master']['github']['adminUserNames']                       = 'adriaanm,retronym,lrytz,chef,scala-jenkins'
+  default['master']['github']['organizationNames']                    = 'scala'
+  default['master']['github']['useRepositoryPermissions']             = 'true'
+  default['master']['github']['allowAnonymousReadPermission']         = 'true'
+  default['master']['github']['authenticatedUserReadPermission']      = 'true'
+  default['master']['github']['allowGithubWebHookPermission']         = 'true'
+  default['master']['github']['allowCcTrayPermission']                = 'false'
+  default['master']['github']['authenticatedUserCreateJobPermission'] = 'false'
 
+  ## CONTACT INFO
+  default['master']['adminAddress']         = "adriaan@typesafe.com"
+  default['master']['jenkinsHost']          = scalaCiHost
+  default['master']['jenkinsUrl']           = "https://#{scalaCiHost}/"
+  default['master']['jenkins']['notifyUrl'] = "http://#{scalaCiHost}:8888/jenkins" # scabot listens here
 
-default['scabot']['jenkins']['user']     = "scala-jenkins"
-default['scabot']['github']['repo_user'] = "scala"
+  # see below (note that default['master']['env'] can only indirect through node -- workerJavaOpts is not in scope)
+  workerJavaOpts = "-Dfile.encoding=UTF-8 -server -XX:+AggressiveOpts -XX:+UseParNewGC -Xmx2G -Xss1M -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=128M -Dpartest.threads=4"
+  default['jenkinsEnv']['JAVA_OPTS']  = workerJavaOpts
+  default['jenkinsEnv']['ANT_OPTS']   = workerJavaOpts
+  default['jenkinsEnv']['MAVEN_OPTS'] = workerJavaOpts # doesn't technically need the -Dpartest one, but oh well
+
+  # NOTE: This is a string that represents a closure that closes over the worker node for which it computes the environment.
+  # (by convention -- see `environment((eval node["master"]["env"])...` in _master-config-workers
+  # Since we can't marshall closures, while attributes need to be sent from master to workers, we must encode them as something that can be shipped...
+  default['master']['env'] = <<-'EOH'.gsub(/^ {2}/, '')
+    lambda{| node | Chef::Node::ImmutableMash.new({
+      "JAVA_HOME"          => node['java']['java_home'], # we get the jre if we don't do this
+      "JAVA_OPTS"          => node['jenkinsEnv']['JAVA_OPTS'],
+      "ANT_OPTS"           => node['jenkinsEnv']['ANT_OPTS'],
+      "MAVEN_OPTS"         => node['jenkinsEnv']['MAVEN_OPTS'],
+      "prRepoUrl"          => node['repos']['private']['pr-snap'],
+      "releaseTempRepoUrl" => node['repos']['private']['release-temp']
+    })}
+    EOH
+
+  ## PLUGIN
+  default['master']['ec2-start-stop']['url'] = 'https://dl.dropboxusercontent.com/u/12862572/ec2-start-stop.hpi'
+
+  # SCABOT
+  default['scabot']['jenkins']['user']     = "scala-jenkins"
+  default['scabot']['github']['repo_user'] = "scala"
+end

--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -27,7 +27,7 @@ default['master']['jenkins']['notifyUrl'] = "http://scala-ci.typesafe.com:8888/j
 
 default['repos']['private']['realm']        = "Artifactory Realm"
 default['repos']['private']['host']         = "private-repo.typesafe.com"
-default['repos']['private']['pr-snap']      = "http://private-repo.typesafe.com/typesafe/scala-pr-validation-snapshots/",
+default['repos']['private']['pr-snap']      = "http://private-repo.typesafe.com/typesafe/scala-pr-validation-snapshots/"
 default['repos']['private']['release-temp'] = "http://private-repo.typesafe.com/typesafe/scala-release-temp/"
 
 default['s3']['downloads']['host'] = "downloads.typesafe.com.s3.amazonaws.com"

--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -9,6 +9,10 @@ default['repos']['private']['release-temp'] = "http://private-repo.typesafe.com/
 default['s3']['downloads']['host'] = "downloads.typesafe.com.s3.amazonaws.com"
 
 if node.name == "jenkins-master"
+  # JAVA
+  default['java']['jdk_version']    = '7'
+  default['java']['install_flavor'] = 'openjdk'
+
   # JENKINS
   override['jenkins']['master']['install_method'] = 'war'
   override['jenkins']['master']['listen_address'] = '127.0.0.1' # external traffic must go through nginx

--- a/attributes/worker.rb
+++ b/attributes/worker.rb
@@ -2,126 +2,127 @@
 workerAuthorizedKeys =
   "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAva5WQeMGZxgQ1adlJQoYZCJZYTkVYSSKWu9O3EDJD+2jncUFfUdd4AsYbpYs/N2FyeoT2Gja7c03dFI6gQP3d+ZNaiO3CBYC6LvbgmCaQrffymiYw8jgD0NQqRan0nwXblmQlkxktgU0oSI/NmkpsNsMx67Pgrd+UsCchuFl7LR0CD6q+URt6Y38TY8F2x4k8P7Y2aWoQOuPk8bvEMALaOetSH0Y8zNEP5YPf7k30Z8ZUyhkt0x166gKoO/2PlzTjy5cAi+sDdCIxd74Ll7jzaUa10BDpl1iOHtLEkTJ0pssENm0g+PvJcsyzGhBRfGSLxEDhBRw1hPRT1avOwIeJQ== lrytz\n"
 
-case node["platform_family"]
-when "windows"
-  # configure windows-specific recipes (attributes not node-specific!)
-  override['java']['windows']['package_name'] = 'Java(TM) SE Development Kit 6 (64-bit)'
-  override['java']['windows']['url']          = 'https://dl.dropboxusercontent.com/u/12862572/jdk-6u45-windows-x64.exe' # if you change this, must change javacVersion below
-  override['java']['windows']['checksum']     = '345059d5bc64275c1d8fdc03625d69c16d0c8730be1c152247f5f96d00b21b00'
-  override['java']['java_home']               = 'C:\java\jdk-1.6' # must specify java_home on windows (issues with installer on reinstall if it's in program files)
-  default['java']['javacVersion']            = "javac 1.6.0_45"  # we don't install if javac -version returns this string
+if (node.name =~ /.*-worker-.*/) != nil
+  case node["platform_family"]
+  when "windows"
+    # configure windows-specific recipes (attributes not node-specific!)
+    override['java']['windows']['package_name'] = 'Java(TM) SE Development Kit 6 (64-bit)'
+    override['java']['windows']['url']          = 'https://dl.dropboxusercontent.com/u/12862572/jdk-6u45-windows-x64.exe' # if you change this, must change javacVersion below
+    override['java']['windows']['checksum']     = '345059d5bc64275c1d8fdc03625d69c16d0c8730be1c152247f5f96d00b21b00'
+    override['java']['java_home']               = 'C:\java\jdk-1.6' # must specify java_home on windows (issues with installer on reinstall if it's in program files)
+    default['java']['javacVersion']            = "javac 1.6.0_45"  # we don't install if javac -version returns this string
 
-  override['sbt']['script_name']   = 'sbt.bat'
-  override['sbt']['launcher_path'] = 'C:\sbt'
-  override['sbt']['bin_path']      = 'C:\sbt'
+    override['sbt']['script_name']   = 'sbt.bat'
+    override['sbt']['launcher_path'] = 'C:\sbt'
+    override['sbt']['bin_path']      = 'C:\sbt'
 
-  # this zip was reworked to have the binaries under the `bin/` directory, which is what sbt-nativepackager expects
-  override['wix']['home']     = 'C:\Program Files (x86)\WiX Toolset v3.9'
-  override['wix']['url']      = 'http://static.wixtoolset.org/releases/v3.9.421.0/wix39.exe'
-  override['wix']['checksum'] = '46eda1dd64bfdfc3cc117e76902d767f1a47a1e40f7b6aad68b32a18b609eb7c'
+    # this zip was reworked to have the binaries under the `bin/` directory, which is what sbt-nativepackager expects
+    override['wix']['home']     = 'C:\Program Files (x86)\WiX Toolset v3.9'
+    override['wix']['url']      = 'http://static.wixtoolset.org/releases/v3.9.421.0/wix39.exe'
+    override['wix']['checksum'] = '46eda1dd64bfdfc3cc117e76902d767f1a47a1e40f7b6aad68b32a18b609eb7c'
 
-  override['cygwin']['home']             = 'c:\cygwin'
-  override['cygwin']['installer']['url'] = "http://cygwin.com/setup-x86_64.exe"
+    override['cygwin']['home']             = 'c:\cygwin'
+    override['cygwin']['installer']['url'] = "http://cygwin.com/setup-x86_64.exe"
 
-  # This zip should contain the "#{Chef::Config[:file_cache_path]}/cygwin" directory,
-  # after it was manually populated by running "#{Chef::Config[:file_cache_path]}/cygwin-setup.exe",
-  # selecting openssh, cygrunsrv in addition to cygwin's base packages.
-  # I did not succeed in automating the cygwin installer without having a local cache of the package archives
-  override['cygwin']['base']['url']      = "https://dl.dropboxusercontent.com/u/12862572/cygwin-base-x64.zip"
-  override['cygwin']['base']['checksum'] = "dab686bc685ba1447240804a47d10f3b146d4b17b6f9fea781ed9bb59c67e664"
+    # This zip should contain the "#{Chef::Config[:file_cache_path]}/cygwin" directory,
+    # after it was manually populated by running "#{Chef::Config[:file_cache_path]}/cygwin-setup.exe",
+    # selecting openssh, cygrunsrv in addition to cygwin's base packages.
+    # I did not succeed in automating the cygwin installer without having a local cache of the package archives
+    override['cygwin']['base']['url']      = "https://dl.dropboxusercontent.com/u/12862572/cygwin-base-x64.zip"
+    override['cygwin']['base']['checksum'] = "dab686bc685ba1447240804a47d10f3b146d4b17b6f9fea781ed9bb59c67e664"
 
-  # TODO: also derive PATH variable from attributes
-  ## Git is installed to Program Files (x86) on 64-bit machines and
-  ## 'Program Files' on 32-bit machines
-  ## PROGRAM_FILES = ENV['ProgramFiles(x86)'] || ENV['ProgramFiles']
-  ## GIT_PATH      = "#{ PROGRAM_FILES }\\Git\\Cmd"
+    # TODO: also derive PATH variable from attributes
+    ## Git is installed to Program Files (x86) on 64-bit machines and
+    ## 'Program Files' on 32-bit machines
+    ## PROGRAM_FILES = ENV['ProgramFiles(x86)'] || ENV['ProgramFiles']
+    ## GIT_PATH      = "#{ PROGRAM_FILES }\\Git\\Cmd"
 
-  jenkinsHome = 'y:\jenkins'
-  jenkinsTmp  = 'y:\tmp'
+    jenkinsHome = 'y:\jenkins'
+    jenkinsTmp  = 'y:\tmp'
 
-  # If node name contains "-publish", configure it with necessary secrets/package to roll & publish a release
-  publisher = (node.name =~ /.*-publish.*/) != nil # TODO: use tag?
+    # If node name contains "-publish", configure it with necessary secrets/package to roll & publish a release
+    publisher = (node.name =~ /.*-publish.*/) != nil # TODO: use tag?
 
-  default['ebs']['volumes']['Y']['size']      = 50
-  default['ebs']['volumes']['Y']['dev']       = "sdj"
-  default['ebs']['volumes']['Y']['disk']      = 'PCIROOT(0)#PCI(1F00)#PCI(1F00)#SCSI(P00T09L00)' # J is the 9th letter in base-0 --> T09(https://technet.microsoft.com/en-us/library/ee851589%28v=ws.10%29.aspx)
+    default['ebs']['volumes']['Y']['size']      = 50
+    default['ebs']['volumes']['Y']['dev']       = "sdj"
+    default['ebs']['volumes']['Y']['disk']      = 'PCIROOT(0)#PCI(1F00)#PCI(1F00)#SCSI(P00T09L00)' # J is the 9th letter in base-0 --> T09(https://technet.microsoft.com/en-us/library/ee851589%28v=ws.10%29.aspx)
 
-  default['ebs']['volumes']['Y']['fstype']    = "ntfs"
-  default['ebs']['volumes']['Y']['user']      = "jenkins"
-  default['ebs']['volumes']['Y']['mountopts'] = ''
+    default['ebs']['volumes']['Y']['fstype']    = "ntfs"
+    default['ebs']['volumes']['Y']['user']      = "jenkins"
+    default['ebs']['volumes']['Y']['mountopts'] = ''
 
-  default["jenkinsHomes"][jenkinsHome]["executors"]   = 2
-  default["jenkinsHomes"][jenkinsHome]["workerName"]  = node.name
-  default["jenkinsHomes"][jenkinsHome]["authorized_keys"] = workerAuthorizedKeys
-  default["jenkinsHomes"][jenkinsHome]["jenkinsUser"] = 'jenkins'
-  default["jenkinsHomes"][jenkinsHome]["jvm_options"] = "-Duser.home=#{jenkinsHome.gsub(/\\/,'/')} -Djava.io.tmpdir=#{jenkinsTmp.gsub(/\\/,'/')}" # jenkins doesn't quote properly
-  default["jenkinsHomes"][jenkinsHome]["labels"]      = ["windows", publisher ? "publish": "public"]
-  default["jenkinsHomes"][jenkinsHome]["publish"]     = publisher
+    default["jenkinsHomes"][jenkinsHome]["executors"]   = 2
+    default["jenkinsHomes"][jenkinsHome]["workerName"]  = node.name
+    default["jenkinsHomes"][jenkinsHome]["authorized_keys"] = workerAuthorizedKeys
+    default["jenkinsHomes"][jenkinsHome]["jenkinsUser"] = 'jenkins'
+    default["jenkinsHomes"][jenkinsHome]["jvm_options"] = "-Duser.home=#{jenkinsHome.gsub(/\\/,'/')} -Djava.io.tmpdir=#{jenkinsTmp.gsub(/\\/,'/')}" # jenkins doesn't quote properly
+    default["jenkinsHomes"][jenkinsHome]["labels"]      = ["windows", publisher ? "publish": "public"]
+    default["jenkinsHomes"][jenkinsHome]["publish"]     = publisher
 
-  default["jenkinsHomes"][jenkinsHome]["usage_mode"]  = 'exclusive' # windows is a speciality node, don't run jobs here unless they asked for a `windows` node
+    default["jenkinsHomes"][jenkinsHome]["usage_mode"]  = 'exclusive' # windows is a speciality node, don't run jobs here unless they asked for a `windows` node
 
-  default["jenkinsHomes"][jenkinsHome]["in_demand_delay"] = 1  # if builds are in queue for even one minute, launch this worker
-  default["jenkinsHomes"][jenkinsHome]["idle_delay"]      = 15 # take worker off-line after 15 min of idling (we're charged by the hour, so no rush)
+    default["jenkinsHomes"][jenkinsHome]["in_demand_delay"] = 1  # if builds are in queue for even one minute, launch this worker
+    default["jenkinsHomes"][jenkinsHome]["idle_delay"]      = 15 # take worker off-line after 15 min of idling (we're charged by the hour, so no rush)
 
-  default["_jenkinsHome"] = jenkinsHome
-  default["_jenkinsTmp"]  = jenkinsTmp
+    default["_jenkinsHome"] = jenkinsHome
+    default["_jenkinsTmp"]  = jenkinsTmp
 
-  # Worker-specific env, the rest is defined in master's attribs.
-  # This needs to be a closure to get laziness so that we can refer to other attributes, but can't marshall closures,
-  # and they sometimes need to be shipped, so encode as string, closing over `node`...
-  default["jenkinsHomes"][jenkinsHome]["env"]         = <<-'EOH'.gsub(/^ {4}/, '')
-    lambda{| node | Chef::Node::ImmutableMash.new({
-      "PATH"          => "/bin:/usr/bin:/cygdrive/c/java/jdk-1.6/bin:/cygdrive/c/Program Files (x86)/Git/Cmd", # TODO express in terms of attributes
-      "sbtLauncher"   => "#{node['sbt']['launcher_path']}\\sbt-launch.jar", # from chef-sbt cookbook
-      "WIX"           => node['wix']['home'],
-      "TMP"           => "#{node['_jenkinsTmp']}",
-      "_JAVA_OPTIONS" => "-Duser.home=#{node['_jenkinsHome']}", # no other way to do this... sbt boot will fail pretty weirdly if it can't write to $HOME/.sbt and $TMP/...
-      "SHELLOPTS"     => "igncr" # ignore line-ending issues in shell scripts
-    })}
-    EOH
+    # Worker-specific env, the rest is defined in master's attribs.
+    # This needs to be a closure to get laziness so that we can refer to other attributes, but can't marshall closures,
+    # and they sometimes need to be shipped, so encode as string, closing over `node`...
+    default["jenkinsHomes"][jenkinsHome]["env"]         = <<-'EOH'.gsub(/^ {4}/, '')
+      lambda{| node | Chef::Node::ImmutableMash.new({
+        "PATH"          => "/bin:/usr/bin:/cygdrive/c/java/jdk-1.6/bin:/cygdrive/c/Program Files (x86)/Git/Cmd", # TODO express in terms of attributes
+        "sbtLauncher"   => "#{node['sbt']['launcher_path']}\\sbt-launch.jar", # from chef-sbt cookbook
+        "WIX"           => node['wix']['home'],
+        "TMP"           => "#{node['_jenkinsTmp']}",
+        "_JAVA_OPTIONS" => "-Duser.home=#{node['_jenkinsHome']}", # no other way to do this... sbt boot will fail pretty weirdly if it can't write to $HOME/.sbt and $TMP/...
+        "SHELLOPTS"     => "igncr" # ignore line-ending issues in shell scripts
+      })}
+      EOH
 
-else
-  # If node name contains "-publish", configure it with necessary secrets/package to roll & publish a release
-  publisher = (node.name =~ /.*-publish.*/) != nil # TODO: use tag?
-  lightWorker = publisher  # TODO: better heuristic...
+  else
+    # If node name contains "-publish", configure it with necessary secrets/package to roll & publish a release
+    publisher = (node.name =~ /.*-publish.*/) != nil # TODO: use tag?
+    lightWorker = publisher  # TODO: better heuristic...
 
-  override['java']['jdk_version']    = '6'
-  override['java']['install_flavor'] = 'oracle' # partest's javap tests fail on openjdk...
-  override['java']['oracle']['accept_oracle_download_terms'] = true
-  # must specify java_home explicitly, or java_ark thinks it's installed even if some other version is...
-  override['java']['java_home'] = platform_family?('debian') ? '/usr/lib/jvm/java-6-oracle-amd64' : '/usr/lib/jvm/java-1.6.0-oracle.x86_64'
+    override['java']['jdk_version']    = '6'
+    override['java']['install_flavor'] = 'oracle' # partest's javap tests fail on openjdk...
+    override['java']['oracle']['accept_oracle_download_terms'] = true
+    # must specify java_home explicitly, or java_ark thinks it's installed even if some other version is...
+    override['java']['java_home'] = platform_family?('debian') ? '/usr/lib/jvm/java-6-oracle-amd64' : '/usr/lib/jvm/java-1.6.0-oracle.x86_64'
 
-  default['graphviz']['url']      = 'https://dl.dropboxusercontent.com/u/12862572/graphviz_2.28.0-1_amd64.deb'
-  default['graphviz']['checksum'] = '76236edc36d5906b93f35e83f8f19a2045318852d3f826e920f189431967c081'
-  default['graphviz']['version']  = '2.28.0-1'
+    default['graphviz']['url']      = 'https://dl.dropboxusercontent.com/u/12862572/graphviz_2.28.0-1_amd64.deb'
+    default['graphviz']['checksum'] = '76236edc36d5906b93f35e83f8f19a2045318852d3f826e920f189431967c081'
+    default['graphviz']['version']  = '2.28.0-1'
 
-  default['ebs']['volumes']['/home/jenkins']['size']      = lightWorker ? 50 : 100 # size of the volume correlates to speed (in IOPS)
-  default['ebs']['volumes']['/home/jenkins']['dev']       = "/dev/sdj"
-  default['ebs']['volumes']['/home/jenkins']['fstype']    = "ext4"
-  default['ebs']['volumes']['/home/jenkins']['user']      = "jenkins"
-  default['ebs']['volumes']['/home/jenkins']['mountopts'] = 'noatime'
+    default['ebs']['volumes']['/home/jenkins']['size']      = lightWorker ? 50 : 100 # size of the volume correlates to speed (in IOPS)
+    default['ebs']['volumes']['/home/jenkins']['dev']       = "/dev/sdj"
+    default['ebs']['volumes']['/home/jenkins']['fstype']    = "ext4"
+    default['ebs']['volumes']['/home/jenkins']['user']      = "jenkins"
+    default['ebs']['volumes']['/home/jenkins']['mountopts'] = 'noatime'
 
-  default["jenkinsHomes"]["/home/jenkins"]["workerName"]      = node.name
-  default["jenkinsHomes"]["/home/jenkins"]["authorized_keys"] = workerAuthorizedKeys
-  default["jenkinsHomes"]["/home/jenkins"]["jenkinsUser"]     = "jenkins"
-  default["jenkinsHomes"]["/home/jenkins"]["publish"]         = publisher
-  default["jenkinsHomes"]["/home/jenkins"]["in_demand_delay"] = 0  # launch worker immediately
-  default["jenkinsHomes"]["/home/jenkins"]["idle_delay"]      = 20 # take worker off-line after 20 min of idling (we're charged by the hour, so no rush)
+    default["jenkinsHomes"]["/home/jenkins"]["workerName"]      = node.name
+    default["jenkinsHomes"]["/home/jenkins"]["authorized_keys"] = workerAuthorizedKeys
+    default["jenkinsHomes"]["/home/jenkins"]["jenkinsUser"]     = "jenkins"
+    default["jenkinsHomes"]["/home/jenkins"]["publish"]         = publisher
+    default["jenkinsHomes"]["/home/jenkins"]["in_demand_delay"] = 0  # launch worker immediately
+    default["jenkinsHomes"]["/home/jenkins"]["idle_delay"]      = 20 # take worker off-line after 20 min of idling (we're charged by the hour, so no rush)
 
-  default["jenkinsHomes"]["/home/jenkins"]["executors"]  = lightWorker ? 2 : 4
-  default["jenkinsHomes"]["/home/jenkins"]["usage_mode"] = publisher ? "exclusive" : "normal"
-  default["jenkinsHomes"]["/home/jenkins"]["labels"]     = ["linux", publisher ? "publish": "public"]
+    default["jenkinsHomes"]["/home/jenkins"]["executors"]  = lightWorker ? 2 : 4
+    default["jenkinsHomes"]["/home/jenkins"]["usage_mode"] = publisher ? "exclusive" : "normal"
+    default["jenkinsHomes"]["/home/jenkins"]["labels"]     = ["linux", publisher ? "publish": "public"]
 
-  # Worker-specific env, the rest is defined in master's attribs.
-  # (note: sshCharaArgs only used on publisher, but doesn't contain any private date, so not bothering to split it out)
-  # This needs to be a closure to get laziness so that we can refer to other attributes, but can't marshall closures,
-  # and they sometimes need to be shipped, so encode as string, closing over `node`...
-  default["jenkinsHomes"]["/home/jenkins"]["env"]         = <<-'EOH'.gsub(/^ {4}/, '')
-    lambda{| node | Chef::Node::ImmutableMash.new({
-      "sshCharaArgs" => '("scalatest@chara.epfl.ch" "-i" "/home/jenkins/.ssh/for_chara")',
-      "sbtLauncher"  => File.join(node['sbt']['launcher_path'], "sbt-launch.jar"), # from chef-sbt cookbook
-      "sbtCmd"       => File.join(node['sbt-extras']['setup_dir'], node['sbt-extras']['script_name']) # sbt-extras
-    })}
-    EOH
-
+    # Worker-specific env, the rest is defined in master's attribs.
+    # (note: sshCharaArgs only used on publisher, but doesn't contain any private date, so not bothering to split it out)
+    # This needs to be a closure to get laziness so that we can refer to other attributes, but can't marshall closures,
+    # and they sometimes need to be shipped, so encode as string, closing over `node`...
+    default["jenkinsHomes"]["/home/jenkins"]["env"]         = <<-'EOH'.gsub(/^ {4}/, '')
+      lambda{| node | Chef::Node::ImmutableMash.new({
+        "sshCharaArgs" => '("scalatest@chara.epfl.ch" "-i" "/home/jenkins/.ssh/for_chara")',
+        "sbtLauncher"  => File.join(node['sbt']['launcher_path'], "sbt-launch.jar"), # from chef-sbt cookbook
+        "sbtCmd"       => File.join(node['sbt-extras']['setup_dir'], node['sbt-extras']['script_name']) # sbt-extras
+      })}
+      EOH
+  end
 end

--- a/files/default/jvm-select
+++ b/files/default/jvm-select
@@ -1,0 +1,5 @@
+source /usr/local/share/jvm/jvm-select-common
+
+#TODO: windows?
+echo "Unsupported platform for jvm-select"
+exit 1

--- a/recipes/_master-init-jenkins.rb
+++ b/recipes/_master-init-jenkins.rb
@@ -7,10 +7,6 @@
 # All rights reserved - Do Not Redistribute
 #
 
-# The jenkins cookbook comes with a very simple java installer. If you need more
-#  complex java installs you are on your own.
-#  https://github.com/opscode-cookbooks/jenkins#java
-include_recipe 'jenkins::java'
 include_recipe 'jenkins::master'
 
 # recursive doesn't set owner correctly??

--- a/recipes/_master-init-jenkins.rb
+++ b/recipes/_master-init-jenkins.rb
@@ -33,8 +33,4 @@ template "#{node['jenkins']['master']['home']}/jenkins.model.JenkinsLocationConf
   source 'jenkins.model.JenkinsLocationConfiguration.xml.erb'
   user node['jenkins']['master']['user']
   group node['jenkins']['master']['group']
-  variables({
-    :adminAddress => node['master']['adminAddress'],
-    :jenkinsUrl   => node['master']['jenkinsUrl']
-  })
 end

--- a/recipes/_master-init-jenkins.rb
+++ b/recipes/_master-init-jenkins.rb
@@ -1,0 +1,44 @@
+#
+# Cookbook Name:: scala-jenkins-infra
+# Recipe:: _master-init-jenkins
+#
+# Copyright 2015, Typesafe, Inc.
+#
+# All rights reserved - Do Not Redistribute
+#
+
+# The jenkins cookbook comes with a very simple java installer. If you need more
+#  complex java installs you are on your own.
+#  https://github.com/opscode-cookbooks/jenkins#java
+include_recipe 'jenkins::java'
+include_recipe 'jenkins::master'
+
+# recursive doesn't set owner correctly??
+directory "#{node['jenkins']['master']['home']}/users" do
+  user node['jenkins']['master']['user']
+  group node['jenkins']['master']['group']
+end
+
+directory "#{node['jenkins']['master']['home']}/users/chef/" do
+  user node['jenkins']['master']['user']
+  group node['jenkins']['master']['group']
+end
+
+
+# NOTE: the following attributes must be configured thusly (jenkins-cli comms will stay in the VPC)
+#   see also on the workers: `node.set['jenkins']['master']['endpoint'] = "http://#{jenkinsMaster.ipaddress}:#{jenkinsMaster.jenkins.master.port}"`
+# under jenkins.master
+    # host: localhost
+    # listen_address: 0.0.0.0
+    # port: 8080
+    # endpoint: http://localhost:8080
+# keep endpoint at localhost (stay in VPC), must set this for reverse proxy to work
+template "#{node['jenkins']['master']['home']}/jenkins.model.JenkinsLocationConfiguration.xml" do
+  source 'jenkins.model.JenkinsLocationConfiguration.xml.erb'
+  user node['jenkins']['master']['user']
+  group node['jenkins']['master']['group']
+  variables({
+    :adminAddress => node['master']['adminAddress'],
+    :jenkinsUrl   => node['master']['jenkinsUrl']
+  })
+end

--- a/recipes/master-init.rb
+++ b/recipes/master-init.rb
@@ -13,8 +13,11 @@ chef_gem "chef-vault"
 include_recipe "scala-jenkins-infra::_master-init-jenkins"
 
 
-# https://github.com/scala/scala-jenkins-infra/issues/26
-# workaround from https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1317811/comments/22 (until we can upgrade to kernel with fix -- >3.16.1)
-execute 'turn off scatter-gatter' do
-  command "ethtool -K eth0 sg off"
+case node["platform"]
+when "amazon"
+  # https://github.com/scala/scala-jenkins-infra/issues/26
+  # workaround from https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1317811/comments/22 (until we can upgrade to kernel with fix -- >3.16.1)
+  execute 'turn off scatter-gatter' do
+    command "ethtool -K eth0 sg off"
+  end
 end

--- a/recipes/master-init.rb
+++ b/recipes/master-init.rb
@@ -10,41 +10,8 @@ include_recipe 'chef-client::service'
 
 chef_gem "chef-vault"
 
-# The jenkins cookbook comes with a very simple java installer. If you need more
-#  complex java installs you are on your own.
-#  https://github.com/opscode-cookbooks/jenkins#java
-include_recipe 'jenkins::java'
-include_recipe 'jenkins::master'
+include_recipe "scala-jenkins-infra::_master-init-jenkins"
 
-# recursive doesn't set owner correctly??
-directory "#{node['jenkins']['master']['home']}/users" do
-  user node['jenkins']['master']['user']
-  group node['jenkins']['master']['group']
-end
-
-directory "#{node['jenkins']['master']['home']}/users/chef/" do
-  user node['jenkins']['master']['user']
-  group node['jenkins']['master']['group']
-end
-
-
-# NOTE: the following attributes must be configured thusly (jenkins-cli comms will stay in the VPC)
-#   see also on the workers: `node.set['jenkins']['master']['endpoint'] = "http://#{jenkinsMaster.ipaddress}:#{jenkinsMaster.jenkins.master.port}"`
-# under jenkins.master
-    # host: localhost
-    # listen_address: 0.0.0.0
-    # port: 8080
-    # endpoint: http://localhost:8080
-# keep endpoint at localhost (stay in VPC), must set this for reverse proxy to work
-template "#{node['jenkins']['master']['home']}/jenkins.model.JenkinsLocationConfiguration.xml" do
-  source 'jenkins.model.JenkinsLocationConfiguration.xml.erb'
-  user node['jenkins']['master']['user']
-  group node['jenkins']['master']['group']
-  variables({
-    :adminAddress => node['master']['adminAddress'],
-    :jenkinsUrl   => node['master']['jenkinsUrl']
-  })
-end
 
 # https://github.com/scala/scala-jenkins-infra/issues/26
 # workaround from https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1317811/comments/22 (until we can upgrade to kernel with fix -- >3.16.1)

--- a/recipes/master-init.rb
+++ b/recipes/master-init.rb
@@ -10,6 +10,8 @@ include_recipe 'chef-client::service'
 
 chef_gem "chef-vault"
 
+include_recipe "java"
+
 include_recipe "scala-jenkins-infra::_master-init-jenkins"
 
 

--- a/templates/default/jenkins.model.JenkinsLocationConfiguration.xml.erb
+++ b/templates/default/jenkins.model.JenkinsLocationConfiguration.xml.erb
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <jenkins.model.JenkinsLocationConfiguration>
-  <adminAddress><%= @adminAddress %></adminAddress>
-  <jenkinsUrl><%= @jenkinsUrl %></jenkinsUrl>
+  <adminAddress><%= node['master']['adminAddress'] %></adminAddress>
+  <jenkinsUrl><%= node['master']['jenkinsUrl'] %></jenkinsUrl>
 </jenkins.model.JenkinsLocationConfiguration>

--- a/templates/default/nginx-jenkins.conf
+++ b/templates/default/nginx-jenkins.conf
@@ -2,7 +2,7 @@ limit_req_zone $binary_remote_addr zone=one:10m rate=1000r/s;
 
 # based on https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+behind+an+NGinX+reverse+proxy
 upstream jenkins {
-  server 127.0.0.1:8080 fail_timeout=0;
+  server 127.0.0.1:<%=node['jenkins']['master']['port']%> fail_timeout=0;
 }
 
 server {


### PR DESCRIPTION
- rework attributes (distinguish nodes with same value on all nodes verse node-specific ones)
- Use standard java recipe instead of jenkins::java (here's when I realized I needed to do the above rework) 
- working Vagrantfile
- factor out jenkins init for master
- fix `default['repos']['private']['pr-snap']`
- clarify readme

this is all laying the groundwork for moving to a new instance for scala-ci that also hosts artifactory (+ EBS storage for repo & jenkins jobs)
