### PR TITLE
deal with symlinks in jvm-select for oracle

### DIFF
--- a/files/default/jvm-select
+++ b/files/default/jvm-select
@@ -5,10 +5,16 @@ function jvmSelect(){
   jvmRoot="/usr/lib/jvm/"
 
   # all javac binaries installed on this machine, pruned to be in directory with expected version/flavor
-  eligibleCmds=$(find $jvmRoot -name "javac" -type f -path "*$jvmMajorVersion*$jvmFlavor*" 2> /dev/null)
+  eligibleCmds=$(find -L $jvmRoot -name "javac" -type f -path "*$jvmMajorVersion*$jvmFlavor*" 2> /dev/null)
 
-  # jdk home is one dir up from where javac is
-  jdkHome=$(for javacCmd in  $eligibleCmds; do if ($javacCmd -version 2>&1 | grep "javac 1\.$jvmMajorVersion" &> /dev/null); then cd $(dirname $javacCmd)/.. && pwd; fi; done)
+  unset jdkHome
+
+  # find first jdk home, where home is one dir up from where javac is
+  for javacCmd in $eligibleCmds; do
+    if [ ! -d "$jdkHome" ] && ($javacCmd -version 2>&1 | grep "javac 1\.$jvmMajorVersion" &> /dev/null); then
+      jdkHome=$(cd $(dirname $javacCmd)/.. && pwd)
+    fi
+  done
 
   if [ -d "$jdkHome" ]; then
     echo "Java home: $jdkHome"


### PR DESCRIPTION
last time I only tested it worked for openjdk 7/8, now it does for oracle 6 as well
also deal with multiple results -- stop at first one that works

blah
