### PR TITLE
Dotty/partest: use ant patterns

### DIFF
--- a/templates/default/jobs/lampepfl/validate/partest.xml.erb
+++ b/templates/default/jobs/lampepfl/validate/partest.xml.erb
@@ -15,7 +15,7 @@
 %>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>tests/partest-generated/*</artifacts>
+      <artifacts>tests/partest-generated/**</artifacts>
       <allowEmptyArchive>false</allowEmptyArchive>
       <onlyIfSuccessful>false</onlyIfSuccessful>
       <fingerprint>false</fingerprint>


### PR DESCRIPTION
ArtifactArchiver passes pattern to jenkins, jenkins passes it to ant.
Ant has it's own language for file patterns, which isn't simply regular expressions.
https://ant.apache.org/manual/dirtasks.html
