### PR TITLE
Centralize jvm selection based on branch

### DIFF
--- a/recipes/_master-jenkins-jobs.rb
+++ b/recipes/_master-jenkins-jobs.rb
@@ -30,12 +30,14 @@ def templDesc(user, repo, branch, path)
   else
     relativePath = m.captures.first
 
-    [ { :templatePath => "jobs/#{user}/#{relativePath}.xml.erb",
-        :scriptName   => "jobs/#{relativePath}",
-        :jobName      => blurbs.versionedJob(repo, branch, relativePath),
-        :user         => user,
-        :repo         => repo, # the main repo (we may refer to other repos under the same user in these jobs)
-        :branch       => branch,
+    [ { :templatePath        => "jobs/#{user}/#{relativePath}.xml.erb",
+        :scriptName          => "jobs/#{relativePath}",
+        :jobName             => blurbs.versionedJob(repo, branch, relativePath),
+        :user                => user,
+        :repo                => repo, # the main repo (we may refer to other repos under the same user in these jobs)
+        :branch              => branch,
+        :jvmFlavorForBranch  => branch == "2.12.x" ? "openjdk" : "oracle",
+        :jvmVersionForBranch => branch == "2.12.x" ? 8         : 6
       }
     ]
   end

--- a/templates/default/jobs/scala/integrate/bootstrap.xml.erb
+++ b/templates/default/jobs/scala/integrate/bootstrap.xml.erb
@@ -14,8 +14,8 @@
     <p> Use github.com/scala/make-release-notes to build the release notes.
    }.gsub(/^    /, ''),
   nodeRestriction: "linux && publish",
-  jvmVersion: 6,
-  jvmFlavor:  "oracle",
+  jvmVersion: @jvmVersionForBranch,
+  jvmFlavor:  @jvmFlavorForBranch,
   params: [
     {:name => "SCALA_VER_BASE",
      :desc => "Specifying this parameter will cause a release to be built. If it&apos;s empty (and HEAD does not have a tag that parses as a version), a -nightly release is built."},

--- a/templates/default/jobs/scala/integrate/community-build.xml.erb
+++ b/templates/default/jobs/scala/integrate/community-build.xml.erb
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <project>
 <%= githubProject(
-  repoUser:    @user,
-  repoName:    "community-builds",
-  repoRef:     @branch,
-  description: "Community Build",
-  nodeRestriction: "public",
+  repoUser:            @user,
+  repoName:            "community-builds",
+  repoRef:             @branch,
+  description:         "Community Build",
+  nodeRestriction:     "public",
   buildTimeoutMinutes: 400,
-  jvmVersion: 6,
-  jvmFlavor:  "oracle")
-%>
+  jvmVersion:          @jvmVersionForBranch,
+  jvmFlavor:           @jvmFlavorForBranch
+) %>
 </project>

--- a/templates/default/jobs/scala/release/smoketest.xml.erb
+++ b/templates/default/jobs/scala/release/smoketest.xml.erb
@@ -10,6 +10,8 @@
     http://downloads.typesafe.com/scala/$version/index.html and makes sure the bundled scripts work.
    }.gsub(/^ {4}/, ''),
   nodeRestriction: "public",
+  jvmVersion: @jvmVersionForBranch,
+  jvmFlavor:  @jvmFlavorForBranch,
   params: [
     {:name => "version", :desc => "The version of scala that we should download the archives for (from http://downloads.typesafe.com/scala/$version/index.html); e.g., 2.10.3-RC2"},
     {:name => "sbtDistVersionOverride", :desc => "Passed to sbt, use instead of version (for experimentation only)."}

--- a/templates/default/jobs/scala/validate/publish-core.xml.erb
+++ b/templates/default/jobs/scala/validate/publish-core.xml.erb
@@ -11,8 +11,8 @@
     {:name => "antBuildArgs", :desc => "TODO"},
     {:name => "_scabot_pr", :desc => "For internal use by Scabot."}
   ],
-  jvmVersion: @branch == "2.11.x" ? 6 : 8,
-  jvmFlavor:  @branch == "2.11.x" ? "oracle" : "openjdk",
+  jvmVersion: @jvmVersionForBranch,
+  jvmFlavor:  @jvmFlavorForBranch,
   buildNameScript: setValidateBuildNameScript)
 %>
   <publishers>


### PR DESCRIPTION
For PR validation, release builds and the community build,
- 2.12.x uses openjdk 8;
- others default to oracle 6.

/cc @lrytz 
