### PR TITLE
Expose arguments passed to ant in scripts

### DIFF
--- a/templates/default/jobs/scala/validate/main.xml.erb
+++ b/templates/default/jobs/scala/validate/main.xml.erb
@@ -7,6 +7,9 @@
     description: "PR validation -- called for every commit in every PR",
     params: [
       {:name => "prDryRun", :desc => ""},
+      {:name => "antBuildArgs", :desc => "Extra arguments for the ant build. For example, `-Dscalac.args=\"-Xcheckinit\"`."},
+      {:name => "testExtraArgs", :desc => "Extra arguments for partest. For example, `-Dpartest.scalac_opts=\"-Xcheckinit\"`."},
+      {:name => "testTarget", :desc => "Ant test targets to call. The default is 'test.core docs.done'."},
       {:name => "_scabot_pr", :desc => "For internal use by Scabot."},
       {:name => "_scabot_last", :desc => "For internal use by Scabot."}
     ],

--- a/templates/default/jobs/scala/validate/publish-core.xml.erb
+++ b/templates/default/jobs/scala/validate/publish-core.xml.erb
@@ -8,7 +8,7 @@
   nodeRestriction: "public",
   params: [
     {:name => "prDryRun", :desc => "Set to 'yep' to try out the jenkins flow."},
-    {:name => "antBuildArgs", :desc => "TODO"},
+    {:name => "antBuildArgs", :desc => "Extra arguments for the ant build. For example, `-Dscalac.args=\"-Xcheckinit\"`."},
     {:name => "_scabot_pr", :desc => "For internal use by Scabot."}
   ],
   jvmVersion: @jvmVersionForBranch,

--- a/templates/default/jobs/scala/validate/test.xml.erb
+++ b/templates/default/jobs/scala/validate/test.xml.erb
@@ -8,8 +8,8 @@
   nodeRestriction: "public",
   params: [
     {:name => "scalaVersion", :desc => "Version of Scala to test. Set by main build flow."},
-    {:name => "testExtraArgs", :desc => "TODO"},
-    {:name => "testTarget", :desc => "TODO"},
+    {:name => "testExtraArgs", :desc => "Extra arguments for partest. For example, `-Dpartest.scalac_opts=\"-Xcheckinit\"`."},
+    {:name => "testTarget", :desc => "Ant test targets to call. The default is 'test.core docs.done'."},
     {:name => "_scabot_pr", :desc => "For internal use by Scabot."}
   ],
   jvmVersion: @branch == "2.11.x" ? 6 : 8,


### PR DESCRIPTION
- `antBuildArgs`  Extra arguments for the ant build. For example, `-Dscalac.args="-Xcheckinit"`.
- `testExtraArgs` Extra arguments for partest. For example, `-Dpartest.scalac_opts="-Xcheckinit"`.
- `testTarget`    Ant test targets to call. The default is 'test.core docs.done'.

The nightly matrix build will use this for the following jobs:
checkinit, rangepos and alternate back-end.
