### PR TITLE
increase timeout from 150 to 210 minutes

### DIFF
--- a/libraries/job_blurbs.rb
+++ b/libraries/job_blurbs.rb
@@ -99,7 +99,7 @@ module ScalaJenkinsInfra
       refspec             = options.fetch(:refspec, stdRefSpec)
       cleanWorkspace      = options.fetch(:cleanWorkspace, true)
       concurrent          = options.fetch(:concurrent, true)
-      buildTimeoutMinutes = options.fetch(:buildTimeoutMinutes, 150)
+      buildTimeoutMinutes = options.fetch(:buildTimeoutMinutes, 210)
       buildNameScript     = options.fetch(:buildNameScript, setBuildNameScript)
 
       jvmFlavor  = options[:jvmFlavor]


### PR DESCRIPTION
because an attempt at a 2.12.0-M2 release build failed today
by running afoul of the old timeout

review/merge by @adriaanm
