### PR TITLE
Remove default global 150 min timeout

### DIFF
--- a/libraries/job_blurbs.rb
+++ b/libraries/job_blurbs.rb
@@ -99,7 +99,7 @@ module ScalaJenkinsInfra
       refspec             = options.fetch(:refspec, stdRefSpec)
       cleanWorkspace      = options.fetch(:cleanWorkspace, true)
       concurrent          = options.fetch(:concurrent, true)
-      buildTimeoutMinutes = options.fetch(:buildTimeoutMinutes, 210)
+      buildTimeoutMinutes = options.fetch(:buildTimeoutMinutes, 150)
       buildNameScript     = options.fetch(:buildNameScript, setBuildNameScript)
 
       jvmFlavor  = options[:jvmFlavor]

--- a/libraries/job_blurbs.rb
+++ b/libraries/job_blurbs.rb
@@ -99,7 +99,7 @@ module ScalaJenkinsInfra
       refspec             = options.fetch(:refspec, stdRefSpec)
       cleanWorkspace      = options.fetch(:cleanWorkspace, true)
       concurrent          = options.fetch(:concurrent, true)
-      buildTimeoutMinutes = options.fetch(:buildTimeoutMinutes, 150)
+      buildTimeoutMinutes = options.fetch(:buildTimeoutMinutes, 0)
       buildNameScript     = options.fetch(:buildNameScript, setBuildNameScript)
 
       jvmFlavor  = options[:jvmFlavor]

--- a/templates/default/jobs/scala/integrate/bootstrap.xml.erb
+++ b/templates/default/jobs/scala/integrate/bootstrap.xml.erb
@@ -14,6 +14,8 @@
     <p> Use github.com/scala/make-release-notes to build the release notes.
    }.gsub(/^    /, ''),
   nodeRestriction: "linux && publish",
+  maxConcurrentPerNode: 1,
+  buildTimeoutMinutes: 200,
   jvmVersion: @jvmVersionForBranch,
   jvmFlavor:  @jvmFlavorForBranch,
   params: [

--- a/templates/default/jobs/scala/integrate/community-build.xml.erb
+++ b/templates/default/jobs/scala/integrate/community-build.xml.erb
@@ -7,8 +7,8 @@
   cleanWorkspace:      false,
   description:         "Community Build",
   nodeRestriction:     "public",
-  buildTimeoutMinutes: 400,
   maxConcurrentPerNode: 1,
+  buildTimeoutMinutes: 400,
   jvmVersion:          @jvmVersionForBranch,
   jvmFlavor:           @jvmFlavorForBranch
 ) %>

--- a/templates/default/jobs/scala/integrate/ide.xml.erb
+++ b/templates/default/jobs/scala/integrate/ide.xml.erb
@@ -7,6 +7,7 @@
   description: "PR integration testing: IDE",
   nodeRestriction: "public",
   maxConcurrentPerNode: 2,
+  buildTimeoutMinutes: 150,
   params: [
     {:name => "scalaVersion", :desc => "Version of Scala to test. Set by main build flow."},
     {:name => "_scabot_pr", :desc => "For internal use by Scabot."},

--- a/templates/default/jobs/scala/validate/publish-core.xml.erb
+++ b/templates/default/jobs/scala/validate/publish-core.xml.erb
@@ -6,6 +6,7 @@
   repoRef:     @branch,
   description: "PR validation: publish core",
   nodeRestriction: "public",
+  buildTimeoutMinutes: 42, # rarely takes more than 10-20 min
   params: [
     {:name => "prDryRun", :desc => "Set to 'yep' to try out the jenkins flow."},
     {:name => "antBuildArgs", :desc => "Extra arguments for the ant build. For example, `-Dscalac.args=\"-Xcheckinit\"`."},

--- a/templates/default/jobs/scala/validate/test.xml.erb
+++ b/templates/default/jobs/scala/validate/test.xml.erb
@@ -7,6 +7,7 @@
   description: "PR validation: test suite",
   nodeRestriction: "public",
   maxConcurrentPerNode: 2,
+  buildTimeoutMinutes: 150,
   params: [
     {:name => "scalaVersion", :desc => "Version of Scala to test. Set by main build flow."},
     {:name => "testExtraArgs", :desc => "Extra arguments for partest. For example, `-Dpartest.scalac_opts=\"-Xcheckinit\"`."},


### PR DESCRIPTION
For now, configure per-job timeouts when at risk of getting stuck.
Later, should use categories, as documented in #102

/cc @SethTisue  -- pushing into prod now
