### PR TITLE
Revert "Don't clean workspace for community build"

### DIFF
--- a/templates/default/jobs/scala/integrate/community-build.xml.erb
+++ b/templates/default/jobs/scala/integrate/community-build.xml.erb
@@ -4,7 +4,6 @@
   repoUser:            @user,
   repoName:            "community-builds",
   repoRef:             @branch,
-  cleanWorkspace:      false,
   description:         "Community Build",
   nodeRestriction:     "public",
   maxConcurrentPerNode: 1,


### PR DESCRIPTION
This reverts commit c59b38e055ab7444e19e511dcc79cf2d4362b21a.

We kept running out of disk space, and, besides,
the most important caching goes to ~jenkins/.dbuild,
so that we don't have to rebuild projects as long
as they can be found there (with the right hash).
