### PR TITLE
Reactive update-api job to update 2.11.x nigtly scaladoc

### DIFF
--- a/templates/default/jobs/scala/release/main.xml.erb
+++ b/templates/default/jobs/scala/release/main.xml.erb
@@ -33,6 +33,8 @@ parallel (
 build(testParams, "#{job("release/smoketest")}")
 
 build(testParams, "#{job("release/website/archives")}")
+
+build(testParams, "#{job("release/website/update-api")}")
 EOX
 ) %>
   <triggers>


### PR DESCRIPTION
The nightly scaladoc for 2.11.x is still published online, but the symlink for the latest one hasn't been updated since January (scala/scala@61caba4, see the title of [the online version](http://www.scala-lang.org/files/archive/nightly/2.11.x/api/2.11.x/))
because this job isn't run anymore.

---

@adriaanm I'm not really a specialist of this stuff, but looking at what the `update-api` script over at scala-dist does, this job should run at the end of every nightly job to update the symlink.
