### PR TITLE
disable non-existent repository that was breaking PR validation

### DIFF
--- a/templates/default/m2-settings-public-jobs.xml.erb
+++ b/templates/default/m2-settings-public-jobs.xml.erb
@@ -48,6 +48,20 @@
       <url>     <%=node['repos']['caching-proxy']['jcenter']['url']%></url>
       <mirrorOf><%=node['repos']['caching-proxy']['jcenter']['mirrorOf']%></mirrorOf>
     </mirror>
+
+    <!--
+      codehaus doesn't exist anymore. it doesn't 404, but serves up
+      bad POMs, so we disable it globally by overriding with a mirror
+      with an invalid URL.
+      this entry could be removed after the scala-ide/scala-refactoring
+      repo removes their reference to codehaus-snapshots from their pom.xml
+    -->
+    <mirror>
+      <id>codehaus-snapshots-mirror</id>
+      <name>Maven Codehaus snapshot repository</name>
+      <url>file:///codehaus-does-not-exist-anymore</url>
+      <mirrorOf>codehaus-snapshots</mirrorOf>
+    </mirror>
   </mirrors>
 
 </settings>

--- a/templates/default/m2-settings.xml.erb
+++ b/templates/default/m2-settings.xml.erb
@@ -40,6 +40,20 @@
       <url>     <%=node['repos']['caching-proxy']['jcenter']['url']%></url>
       <mirrorOf><%=node['repos']['caching-proxy']['jcenter']['mirrorOf']%></mirrorOf>
     </mirror>
+
+    <!--
+      codehaus doesn't exist anymore. it doesn't 404, but serves up
+      bad POMs, so we disable it globally by overriding with a mirror
+      with an invalid URL.
+      this entry could be removed after the scala-ide/scala-refactoring
+      repo removes their reference to codehaus-snapshots from their pom.xml
+    -->
+    <mirror>
+      <id>codehaus-snapshots-mirror</id>
+      <name>Maven Codehaus snapshot repository</name>
+      <url>file:///codehaus-does-not-exist-anymore</url>
+      <mirrorOf>codehaus-snapshots</mirrorOf>
+    </mirror>
   </mirrors>
 
 </settings>


### PR DESCRIPTION
fixes #116 

this change is already in production. an example of a PR validation that passed after the change is https://github.com/scala/scala/pull/4695

review by @adriaanm
