### PR TITLE
increase community build timeout from 400 to 600 minutes

### DIFF
--- a/templates/default/jobs/scala/integrate/community-build.xml.erb
+++ b/templates/default/jobs/scala/integrate/community-build.xml.erb
@@ -7,7 +7,7 @@
   description:         "Community Build",
   nodeRestriction:     "public",
   maxConcurrentPerNode: 1,
-  buildTimeoutMinutes: 400,
+  buildTimeoutMinutes: 600,
   jvmVersion:          @jvmVersionForBranch,
   jvmFlavor:           @jvmFlavorForBranch,
   params: [


### PR DESCRIPTION
the builds are routinely timing out when the Scala SHA has changed

already in production, requested by @lrytz. after-the-fact review by
@adriaanm if he wants.
