### PR TITLE
Archive JVM crash logs as build artifacts

### DIFF
--- a/templates/default/jobs/scala/validate/publish-core.xml.erb
+++ b/templates/default/jobs/scala/validate/publish-core.xml.erb
@@ -18,7 +18,7 @@
 %>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>jenkins.properties</artifacts>
+      <artifacts>jenkins.properties,hs_err_*.log</artifacts>
       <allowEmptyArchive>false</allowEmptyArchive>
       <onlyIfSuccessful>false</onlyIfSuccessful>
       <fingerprint>false</fingerprint>

--- a/templates/default/jobs/scala/validate/test.xml.erb
+++ b/templates/default/jobs/scala/validate/test.xml.erb
@@ -20,7 +20,7 @@
 %>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>build/junit/TEST-*,build/osgi/TEST-*</artifacts>
+      <artifacts>build/junit/TEST-*,build/osgi/TEST-*,hs_err_*.log</artifacts>
       <allowEmptyArchive>true</allowEmptyArchive>
       <onlyIfSuccessful>false</onlyIfSuccessful>
       <fingerprint>false</fingerprint>


### PR DESCRIPTION
In response to:

  https://scala-ci.typesafe.com/job/scala-2.12.x-validate-test/505/console

Review by @SethTisue 
