### PR TITLE
pin community builds to particular behemoths & run them weekly

### DIFF
--- a/recipes/_master-jenkins-jobs.rb
+++ b/recipes/_master-jenkins-jobs.rb
@@ -38,7 +38,8 @@ def templDesc(user, repo, branch, path)
         :branch              => branch,
         :scalaBranchForBranch=> branch == "2.11.x-jdk8" ? "2.11.x" : branch,
         :jvmFlavorForBranch  => branch != "2.11.x" ? "openjdk" : "oracle",
-        :jvmVersionForBranch => branch != "2.11.x" ? 8         : 6
+        :jvmVersionForBranch => branch != "2.11.x" ? 8         : 6,
+        :behemothForBranch   => branch == "2.12.x" ? 2         : 1   # for community builds
       }
     ]
   end

--- a/templates/default/jobs/scala/integrate/community-build.xml.erb
+++ b/templates/default/jobs/scala/integrate/community-build.xml.erb
@@ -15,6 +15,11 @@
     {:name => "scalac_opts", :desc => "Scala compiler arguments, e.g., -Yopt:l:classpath"}
   ]
 ) %>
+  <triggers>
+    <hudson.triggers.TimerTrigger>
+      <spec>@weekly</spec>
+    </hudson.triggers.TimerTrigger>
+  </triggers>
   <publishers>
     <hudson.tasks.Mailer plugin="mailer@1.8">
       <recipients>adriaan@typesafe.com seth.tisue@typesafe.com</recipients>

--- a/templates/default/jobs/scala/integrate/community-build.xml.erb
+++ b/templates/default/jobs/scala/integrate/community-build.xml.erb
@@ -5,7 +5,7 @@
   repoName:            "community-builds",
   repoRef:             @branch,
   description:         "Community Build",
-  nodeRestriction:     "public",
+  nodeRestriction:     "jenkins-worker-behemoth-#{@behemothForBranch}",
   maxConcurrentPerNode: 1,
   buildTimeoutMinutes: 600,
   jvmVersion:          @jvmVersionForBranch,


### PR DESCRIPTION
to take better advantage of dbuild cache. fixes #135

review by @adriaanm, but this is already in production (and
I see the right values showing up in the Jenkins web UI)
