### PR TITLE
Avoid a NPE in the build flow after publish-core fails.

### DIFF
--- a/templates/default/jobs/scala/integrate/main.xml.erb-TODO
+++ b/templates/default/jobs/scala/integrate/main.xml.erb-TODO
@@ -16,6 +16,12 @@ upstreamBuild = build(params, "#{job("integrate/bootstrap")}").build
 // defines maven.version.number
 upstreamPropsArtifact = upstreamBuild.artifacts.find{it.name == "versions.properties"}
 
+if (upstreamPropsArtifact == null) {
+  out.println('Error: publish-core did not publish "jenkins.properties" artifact, unable to proceed.')
+  build.state.setResult(Result.FAILURE)
+  return
+}
+
 buildVersionProps = new java.util.Properties()
 buildVersionProps.load(new java.io.FileInputStream(upstreamPropsArtifact.file))
 

--- a/templates/default/jobs/scala/release/main.xml.erb
+++ b/templates/default/jobs/scala/release/main.xml.erb
@@ -20,6 +20,12 @@ upstreamBuild = buildRun.build
 // defines repo_ref, version, sbtDistVersionOverride
 upstreamPropsArtifact = upstreamBuild.artifacts.find{it.name == "jenkins.properties"}
 
+if (upstreamPropsArtifact == null) {
+  out.println('Error: publish-core did not publish "jenkins.properties" artifact, unable to proceed.')
+  build.state.setResult(Result.FAILURE)
+  return
+}
+
 buildVersionProps = new java.util.Properties()
 buildVersionProps.load(new java.io.FileInputStream(upstreamPropsArtifact.file))
 

--- a/templates/default/jobs/scala/validate/main.xml.erb
+++ b/templates/default/jobs/scala/validate/main.xml.erb
@@ -23,6 +23,12 @@ upstreamBuild = build(params, "#{job("validate/publish-core")}").build
 // defines maven.version.number
 upstreamPropsArtifact = upstreamBuild.artifacts.find{it.name == "jenkins.properties"}
 
+if (upstreamPropsArtifact == null) {
+  out.println('Error: publish-core did not publish "jenkins.properties" artifact, unable to proceed.')
+  build.state.setResult(Result.FAILURE)
+  return
+}
+
 buildVersionProps = new java.util.Properties()
 buildVersionProps.load(new java.io.FileInputStream(upstreamPropsArtifact.file))
 


### PR DESCRIPTION
Before, the output was:

```
Started by user scala-jenkins
Notifying endpoint 'HTTP:http://scala-ci.typesafe.com:8888/jenkins'
Schedule job scala-2.12.x-validate-publish-core
Build scala-2.12.x-validate-publish-core #691 started
scala-2.12.x-validate-publish-core [691] scala/scala#4842 at ecfbe3 completed  : FAILURE
ERROR: Failed to run DSL Script
java.lang.NullPointerException: Cannot get property 'file' on null object
    at org.codehaus.groovy.runtime.NullObject.getProperty(NullObject.java:56)
    at org.codehaus.groovy.runtime.InvokerHelper.getProperty(InvokerHelper.java:156)
    at org.codehaus.groovy.runtime.callsite.NullCallSite.getProperty(NullCallSite.java:44)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGetProperty(AbstractCallSite.java:227)
    at Script1.run(Script1.groovy:17)
    at Script1$run.call(Unknown Source)
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:42)
    at Script1$run.call(Unknown Source)
    at com.cloudbees.plugins.flow.FlowDSL.executeFlowScript(FlowDSL.groovy:84)
    at com.cloudbees.plugins.flow.FlowRun$FlyweightTaskRunnerImpl.run(FlowRun.java:219)
    at hudson.model.Run.execute(Run.java:1744)
    at com.cloudbees.plugins.flow.FlowRun.run(FlowRun.java:155)
    at hudson.model.ResourceController.execute(ResourceController.java:98)
    at hudson.model.Executor.run(Executor.java:374)
FATAL: Cannot get property 'file' on null object
java.lang.NullPointerException: Cannot get property 'file' on null object
    at org.codehaus.groovy.runtime.NullObject.getProperty(NullObject.java:56)
    at org.codehaus.groovy.runtime.InvokerHelper.getProperty(InvokerHelper.java:156)
    at org.codehaus.groovy.runtime.callsite.NullCallSite.getProperty(NullCallSite.java:44)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGetProperty(AbstractCallSite.java:227)
    at Script1.run(Script1.groovy:17)
    at Script1$run.call(Unknown Source)
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:42)
    at Script1$run.call(Unknown Source)
    at com.cloudbees.plugins.flow.FlowDSL.executeFlowScript(FlowDSL.groovy:84)
    at com.cloudbees.plugins.flow.FlowRun$FlyweightTaskRunnerImpl.run(FlowRun.java:219)
    at hudson.model.Run.execute(Run.java:1744)
    at com.cloudbees.plugins.flow.FlowRun.run(FlowRun.java:155)
    at hudson.model.ResourceController.execute(ResourceController.java:98)
    at hudson.model.Executor.run(Executor.java:374)
Notifying endpoint 'HTTP:http://scala-ci.typesafe.com:8888/jenkins'
Finished: FAILURE
```

Review by @SethTisue 

I haven't tried this out
