### PR TITLE
there is no need for PR validation failures to generate email

### DIFF
--- a/templates/default/jobs/scala/validate/main.xml.erb
+++ b/templates/default/jobs/scala/validate/main.xml.erb
@@ -41,12 +41,4 @@ parallel (
 
 EOX
 ) %>
-  <publishers>
-    <hudson.tasks.Mailer plugin="mailer@1.8">
-      <recipients>adriaan@typesafe.com seth.tisue@typesafe.com</recipients>
-      <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
-      <sendToIndividuals>false</sendToIndividuals>
-    </hudson.tasks.Mailer>
-  </publishers>
-  <buildNeedsWorkspace>true</buildNeedsWorkspace>
 </com.cloudbees.plugins.flow.BuildFlow>


### PR DESCRIPTION
we will find out on GitHub.

these emails weren't even being sent until #148 was fixed, otherwise
we probably would have disabled this long ago.
