### PR TITLE
temporarily remove integrate-ide as a part of integrate-main

### DIFF
--- a/templates/default/jobs/scala/validate/main.xml.erb
+++ b/templates/default/jobs/scala/validate/main.xml.erb
@@ -34,10 +34,7 @@ buildVersionProps.load(new java.io.FileInputStream(upstreamPropsArtifact.file))
 
 testParams = params + [ "scalaVersion" : buildVersionProps["maven.version.number"] ]
 
-parallel (
-   { build(testParams, "#{job("validate/test")}") },
-   { retry(2, { build(testParams, "#{job("integrate/ide")}") }) }
-)
+build(testParams, "#{job("validate/test")}")
 
 EOX
 ) %>


### PR DESCRIPTION
should be reinstated once the ScalaIDE folks have
tackled https://github.com/scala/scala-dev/issues/71
