### PR TITLE
dotty junit: don't fail if the archive is empty

### DIFF
--- a/templates/default/jobs/lampepfl/validate/junit.xml.erb
+++ b/templates/default/jobs/lampepfl/validate/junit.xml.erb
@@ -16,7 +16,7 @@
   <publishers>
     <hudson.tasks.ArtifactArchiver>
       <artifacts>hs_err_*.log</artifacts>
-      <allowEmptyArchive>false</allowEmptyArchive>
+      <allowEmptyArchive>true</allowEmptyArchive>
       <onlyIfSuccessful>false</onlyIfSuccessful>
       <fingerprint>false</fingerprint>
       <defaultExcludes>true</defaultExcludes>


### PR DESCRIPTION
hs_err_*.log files will only be present if a JVM crash, otherwise there
is nothing to archive, but the build should still succeed.

Review by @SethTisue or @adriaanm 
