### PR TITLE
increase community build timeouts

### DIFF
--- a/templates/default/jobs/scala/integrate/community-build.xml.erb
+++ b/templates/default/jobs/scala/integrate/community-build.xml.erb
@@ -7,7 +7,7 @@
   description:         "Community Build",
   nodeRestriction:     "jenkins-worker-behemoth-#{@behemothForBranch}",
   maxConcurrentPerNode: 1,
-  buildTimeoutMinutes: 600,
+  buildTimeoutMinutes: 720,
   jvmVersion:          @jvmVersionForBranch,
   jvmFlavor:           @jvmFlavorForBranch,
   params: [


### PR DESCRIPTION
when the Scala version bumps, it's now become routine for the build to
hit the old 600 minute limit and time out.

we have continued to gradually add projects (and additional
resolvers), and existing projects can be expected to gradually add
dependencies and grow their test suites and so forth, so I'm not too
alarmed about it.

in practice, the usual way of coping with this is to fix the Scala
SHA whenever manually triggering test runs, so that the whole thing
doesn't have to be redone from scratch.

admittedly, the build is still slower than we would like! the ticket
on that is https://github.com/scala/community-builds/issues/152
