### PR TITLE
Set 2 hours timeout for Dotty jobs

### DIFF
--- a/templates/default/jobs/lampepfl/validate/junit.xml.erb
+++ b/templates/default/jobs/lampepfl/validate/junit.xml.erb
@@ -6,6 +6,7 @@
   repoRef:     @branch,
   description: "PR validation",
   nodeRestriction: "public",
+  buildTimeoutMinutes: 120,
   params: [
     {:name => "_scabot_pr", :desc => "For internal use by Scabot."}
   ],

--- a/templates/default/jobs/lampepfl/validate/partest-bootstrapped.xml.erb
+++ b/templates/default/jobs/lampepfl/validate/partest-bootstrapped.xml.erb
@@ -6,6 +6,7 @@
   repoRef:     @branch,
   description: "PR validation",
   nodeRestriction: "public",
+  buildTimeoutMinutes: 120,
   params: [
     {:name => "_scabot_pr", :desc => "For internal use by Scabot."}
   ],

--- a/templates/default/jobs/lampepfl/validate/partest.xml.erb
+++ b/templates/default/jobs/lampepfl/validate/partest.xml.erb
@@ -6,6 +6,7 @@
   repoRef:     @branch,
   description: "PR validation",
   nodeRestriction: "public",
+  buildTimeoutMinutes: 120,
   params: [
     {:name => "_scabot_pr", :desc => "For internal use by Scabot."}
   ],


### PR DESCRIPTION
Apparently the default for Jenkins is 24 hours which is much too long.
Our tests shouldn't take longer than ~30 minutes so 2 hours is very
conservative.

CC @DarkDimius 
