### PR TITLE
Upgrade artifactory so that we can use repo layouts

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,14 @@ default['s3']['downloads']['host'] = "downloads.typesafe.com.s3.amazonaws.com"
 # sbt is used by Scabot and by the dotty build, and in some glorious future, the scala build too
 default["sbt-extras"]["download_url"] = "https://raw.githubusercontent.com/paulp/sbt-extras/968cd027dabf894bae63efd2a671aae74390d81f/sbt"
 
+# JAVA
+default['java']['jdk_version']    = '8'
+default['java']['install_flavor'] = 'openjdk'
+
+# the artifactory recipe does `node.set['java']['jdk_version'] = 7` unless this is false....
+default['artifactory']['install_java'] = false
+
+
 # attributes only needed on jenkins-master
 if node.name == "jenkins-master"
   # EBS
@@ -42,10 +50,6 @@ if node.name == "jenkins-master"
   default['ebs']['volumes']['/var/lib/artifactory']['user']      = "artifactory"
   default['ebs']['volumes']['/var/lib/artifactory']['mountopts'] = 'noatime'
 
-  # JAVA
-  default['java']['jdk_version']    = '8'
-  default['java']['install_flavor'] = 'openjdk'
-
   # ARTIFACTORY
   default['artifactory']['zip_url']            = 'https://dl.bintray.com/content/jfrog/artifactory/jfrog-artifactory-oss-4.7.4.zip?direct'
   default['artifactory']['zip_checksum']       = '05ccc6371a6adce0edb7d484a066e3556a660d9359b9bef594aad2128c1784f2'
@@ -58,7 +62,6 @@ if node.name == "jenkins-master"
   default['artifactory']['proxyPort']          = scalaCiPort
   default['artifactory']['address']            = "localhost"
   default['artifactory']['port']               = 8282 # internal use over http
-  default['artifactory']['install_java']       = false
 
   # JENKINS
   override['jenkins']['master']['install_method'] = 'war'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,13 @@ default["sbt-extras"]["download_url"] = "https://raw.githubusercontent.com/paulp
 default['java']['jdk_version']    = '8'
 default['java']['install_flavor'] = 'openjdk'
 
+# used to have this on workers to default to java 6 -- need to default to java 8 for modern jenkins
+# override['java']['jdk_version']    = '6'
+# override['java']['install_flavor'] = 'oracle' # partest's javap tests fail on openjdk...
+# override['java']['oracle']['accept_oracle_download_terms'] = true
+# # must specify java_home explicitly, or java_ark thinks it's installed even if some other version is...
+# override['java']['java_home'] = platform_family?('debian') ? '/usr/lib/jvm/java-6-oracle-amd64' : '/usr/lib/jvm/java-1.6.0-oracle.x86_64'
+
 # the artifactory recipe does `node.set['java']['jdk_version'] = 7` unless this is false....
 default['artifactory']['install_java'] = false
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,12 +43,12 @@ if node.name == "jenkins-master"
   default['ebs']['volumes']['/var/lib/artifactory']['mountopts'] = 'noatime'
 
   # JAVA
-  default['java']['jdk_version']    = '7'
+  default['java']['jdk_version']    = '8'
   default['java']['install_flavor'] = 'openjdk'
 
   # ARTIFACTORY
-  default['artifactory']['zip_url']            = 'http://dl.bintray.com/content/jfrog/artifactory/artifactory-3.6.0.zip?direct'
-  default['artifactory']['zip_checksum']       = '72c375ab659d302da0b196349e152f3d799c3cada2f4d09f9399281a06d880e8'
+  default['artifactory']['zip_url']            = 'https://dl.bintray.com/content/jfrog/artifactory/jfrog-artifactory-oss-4.7.4.zip?direct'
+  default['artifactory']['zip_checksum']       = '05ccc6371a6adce0edb7d484a066e3556a660d9359b9bef594aad2128c1784f2'
   default['artifactory']['home']               = '/var/lib/artifactory'
   default['artifactory']['log_dir']            = '/var/lib/artifactory/logs'
   default['artifactory']['java']['xmx']        = '2g'
@@ -89,11 +89,9 @@ if node.name == "jenkins-master"
   override['jenkins']['master']['jvm_options']    = '-server -Xmx4G -XX:MaxPermSize=512M -XX:+HeapDumpOnOutOfMemoryError -Dhudson.model.User.allowNonExistentUserToLogin=true -Dorg.eclipse.jetty.server.Request.maxFormContentSize=1000000' #
   # -Dfile.encoding=UTF-8
 
-  # PIN to 1.611 because later ones require Java 7 on workers...
-  # To pin the jenkins version, must also override override['jenkins']['master']['source'] !!!
-  override['jenkins']['master']['version']  = '1.611'
+  override['jenkins']['master']['version']  = '1.658'
   override['jenkins']['master']['source']   = "#{node['jenkins']['master']['mirror']}/war/#{node['jenkins']['master']['version']}/jenkins.war"
-  override['jenkins']['master']['checksum'] = '12157975cd8c5bf54bbafdc16d826fd384d7eea5e3816c2c28f82002ad866e42'
+  override['jenkins']['master']['checksum'] = '108a496a01361e598cacbcdc8fcf4070e4dab215fb76f759dd75384af7104a3c'
 
   ## GITHUB OAUTH
   default['master']['github']['webUri']                               = 'https://github.com/'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,15 +28,10 @@ default['s3']['downloads']['host'] = "downloads.typesafe.com.s3.amazonaws.com"
 default["sbt-extras"]["download_url"] = "https://raw.githubusercontent.com/paulp/sbt-extras/968cd027dabf894bae63efd2a671aae74390d81f/sbt"
 
 # JAVA
+# TODO does this actually do anything???
+# it seemed I had to do a `node.set['java']['jdk_version'] = 8` on jenkins-master to actually get this to work
 default['java']['jdk_version']    = '8'
 default['java']['install_flavor'] = 'openjdk'
-
-# used to have this on workers to default to java 6 -- need to default to java 8 for modern jenkins
-# override['java']['jdk_version']    = '6'
-# override['java']['install_flavor'] = 'oracle' # partest's javap tests fail on openjdk...
-# override['java']['oracle']['accept_oracle_download_terms'] = true
-# # must specify java_home explicitly, or java_ark thinks it's installed even if some other version is...
-# override['java']['java_home'] = platform_family?('debian') ? '/usr/lib/jvm/java-6-oracle-amd64' : '/usr/lib/jvm/java-1.6.0-oracle.x86_64'
 
 # the artifactory recipe does `node.set['java']['jdk_version'] = 7` unless this is false....
 default['artifactory']['install_java'] = false

--- a/attributes/worker.rb
+++ b/attributes/worker.rb
@@ -61,7 +61,7 @@ if (node.name =~ /.*-worker-.*/) != nil
     # and they sometimes need to be shipped, so encode as string, closing over `node`...
     default["jenkinsHomes"][jenkinsHome]["env"]         = <<-'EOH'.gsub(/^ {4}/, '')
       lambda{| node | Chef::Node::ImmutableMash.new({
-        "PATH"          => "/bin:/usr/bin:/cygdrive/c/Program Files/Java/jdk1.8.0_92:/cygdrive/c/Program Files (x86)/Git-2.5.3/Cmd", # TODO express in terms of attributes
+        "PATH"          => "/bin:/usr/bin:/cygdrive/c/Program Files/Java/jdk1.8.0_92/bin:/cygdrive/c/Program Files (x86)/Git-2.5.3/Cmd", # TODO express in terms of attributes
         "sbtLauncher"   => "#{node['sbt']['launcher_path']}\\sbt-launch.jar", # from chef-sbt cookbook
         "WIX"           => node['wix']['home'],
         "TMP"           => "#{node['_jenkinsTmp']}",

--- a/attributes/worker.rb
+++ b/attributes/worker.rb
@@ -1,12 +1,6 @@
 if (node.name =~ /.*-worker-.*/) != nil
   case node["platform_family"]
   when "windows"
-    # configure windows-specific recipes (attributes not node-specific!)
-    override['java']['windows']['package_name'] = 'Java(TM) SE Development Kit 6 (64-bit)'
-    override['java']['windows']['url']          = 'https://dl.dropboxusercontent.com/u/12862572/jdk-6u45-windows-x64.exe' # if you change this, must change javacVersion below
-    override['java']['windows']['checksum']     = '345059d5bc64275c1d8fdc03625d69c16d0c8730be1c152247f5f96d00b21b00'
-    override['java']['java_home']               = 'C:\java\jdk-1.6' # must specify java_home on windows (issues with installer on reinstall if it's in program files)
-    default['java']['javacVersion']            = "javac 1.6.0_45"  # we don't install if javac -version returns this string
 
     override['sbt']['script_name']   = 'sbt.bat'
     override['sbt']['launcher_path'] = 'C:\sbt'
@@ -67,7 +61,7 @@ if (node.name =~ /.*-worker-.*/) != nil
     # and they sometimes need to be shipped, so encode as string, closing over `node`...
     default["jenkinsHomes"][jenkinsHome]["env"]         = <<-'EOH'.gsub(/^ {4}/, '')
       lambda{| node | Chef::Node::ImmutableMash.new({
-        "PATH"          => "/bin:/usr/bin:/cygdrive/c/java/jdk-1.6/bin:/cygdrive/c/Program Files (x86)/Git-2.5.3/Cmd", # TODO express in terms of attributes
+        "PATH"          => "/bin:/usr/bin:/cygdrive/c/Program Files/Java/jdk1.8.0_92:/cygdrive/c/Program Files (x86)/Git-2.5.3/Cmd", # TODO express in terms of attributes
         "sbtLauncher"   => "#{node['sbt']['launcher_path']}\\sbt-launch.jar", # from chef-sbt cookbook
         "WIX"           => node['wix']['home'],
         "TMP"           => "#{node['_jenkinsTmp']}",

--- a/attributes/worker.rb
+++ b/attributes/worker.rb
@@ -45,6 +45,7 @@ if (node.name =~ /.*-worker-.*/) != nil
     default["jenkinsHomes"][jenkinsHome]["workerName"]  = node.name
     default["jenkinsHomes"][jenkinsHome]["jenkinsUser"] = 'jenkins'
     default["jenkinsHomes"][jenkinsHome]["jvm_options"] = "-Duser.home=#{jenkinsHome.gsub(/\\/,'/')} -Djava.io.tmpdir=#{jenkinsTmp.gsub(/\\/,'/')}" # jenkins doesn't quote properly
+    default["jenkinsHomes"][jenkinsHome]["java_path"] = '"/cygdrive/c/Program Files/Java/jdk1.8.0_92/bin/java"'
     default["jenkinsHomes"][jenkinsHome]["labels"]      = ["windows", publisher ? "publish": "public"]
     default["jenkinsHomes"][jenkinsHome]["publish"]     = publisher
 

--- a/attributes/worker.rb
+++ b/attributes/worker.rb
@@ -81,12 +81,6 @@ if (node.name =~ /.*-worker-.*/) != nil
     publisher = (node.name =~ /.*-publish.*/) != nil # TODO: use tag?
     lightWorker = publisher  # TODO: better heuristic...
 
-    override['java']['jdk_version']    = '6'
-    override['java']['install_flavor'] = 'oracle' # partest's javap tests fail on openjdk...
-    override['java']['oracle']['accept_oracle_download_terms'] = true
-    # must specify java_home explicitly, or java_ark thinks it's installed even if some other version is...
-    override['java']['java_home'] = platform_family?('debian') ? '/usr/lib/jvm/java-6-oracle-amd64' : '/usr/lib/jvm/java-1.6.0-oracle.x86_64'
-
     default['graphviz']['url']      = 'https://dl.dropboxusercontent.com/u/12862572/graphviz_2.28.0-1_amd64.deb'
     default['graphviz']['checksum'] = '76236edc36d5906b93f35e83f8f19a2045318852d3f826e920f189431967c081'
     default['graphviz']['version']  = '2.28.0-1'

--- a/doc/staging.md
+++ b/doc/staging.md
@@ -48,7 +48,7 @@ knife cookbook site install chef-vault
  - 7-zip               ==  1.0.2
  - apt                 ==  2.7.0
  - ark                 ==  0.9.0
- - artifactory         ==  0.1.1
+ - artifactory         ==  0.3.1
  - aws                 ==  2.7.0
  - build-essential     ==  2.2.3
  - chef-client         ==  4.3.0

--- a/doc/staging.md
+++ b/doc/staging.md
@@ -16,6 +16,7 @@ They may be out of date.  Adriaan has done this; Seth has not.
 I think you can safely ignore `ERROR: IOError: Cannot open or read **/metadata.rb!` in the below
 
 ```
+knife cookbook site install java
 knife cookbook site install cron
 knife cookbook site install logrotate
 knife cookbook site install chef_handler
@@ -58,6 +59,7 @@ knife cookbook site install chef-vault
  - ebs                 ==  0.3.6
  - git                 ==  4.2.2
  - git_user            ==  0.3.1
+ - java                ==  1.39.0
  - logrotate           ==  1.9.1
  - packagecloud        ==  0.0.17
  - partial_search      ==  1.0.8
@@ -74,7 +76,6 @@ knife cookbook site install chef-vault
 
 ```
 knife cookbook github install adriaanm/jenkins/fix305  # custom fixes + https://github.com/opscode-cookbooks/jenkins/pull/313 (b-dean/jenkins/http_ca_fixes)
-knife cookbook github install adriaanm/java/windows-jdk1.6  # jdk 1.6 installer barfs on re-install -- wipe its INSTALLDIR
 knife cookbook github install adriaanm/chef-sbt
 knife cookbook github install gildegoma/chef-sbt-extras
 knife cookbook github install adriaanm/artifactory

--- a/doc/staging.md
+++ b/doc/staging.md
@@ -48,7 +48,6 @@ knife cookbook site install chef-vault
  - 7-zip               ==  1.0.2
  - apt                 ==  2.7.0
  - ark                 ==  0.9.0
- - artifactory         ==  0.3.1
  - aws                 ==  2.7.0
  - build-essential     ==  2.2.3
  - chef-client         ==  4.3.0

--- a/recipes/_java_packages.rb
+++ b/recipes/_java_packages.rb
@@ -7,7 +7,8 @@
 # All rights reserved - Do Not Redistribute
 #
 
-# oracle 6 is installed by default on workers using the java package
+# TODO: install oracle 6 (it's currently installed, but we'll need to automate this if we add/redo nodes)
+
 (platform_family?('debian') ? %w{openjdk-7-jdk openjdk-8-jdk} : %w{java-1.7.0-openjdk-devel java-1.8.0-openjdk-devel}).each do |pkg|
   package pkg
 end

--- a/recipes/_master-jenkins-workers.rb
+++ b/recipes/_master-jenkins-workers.rb
@@ -57,13 +57,13 @@ search(:node, 'name:jenkins-worker*').each do |worker|
       in_demand_delay workerConfig["in_demand_delay"]
       idle_delay      workerConfig["idle_delay"]
 
-      puts "Env for #{worker.name}:"
-      puts "masterEnvLambda: #{masterEnvLambda}"
-      puts "workerEnvLambda: #{workerEnvLambda}"
+      # puts "Env for #{worker.name}:"
+      # puts "masterEnvLambda: #{masterEnvLambda}"
+      # puts "workerEnvLambda: #{workerEnvLambda}"
       masterEnv = (eval masterEnvLambda).call(worker)
-      puts "masterEnv: #{masterEnv}"
+      # puts "masterEnv: #{masterEnv}"
       workerEnv = (eval workerEnvLambda).call(worker)
-      puts "workerEnv: #{workerEnv}"
+      # puts "workerEnv: #{workerEnv}"
 
       environment(masterEnv.merge(workerEnv))
 

--- a/recipes/_master-jenkins-workers.rb
+++ b/recipes/_master-jenkins-workers.rb
@@ -46,6 +46,8 @@ search(:node, 'name:jenkins-worker*').each do |worker|
       remote_fs   jenkinsHome.dup
       jvm_options workerConfig["jvm_options"]
 
+      java_path   workerConfig["java_path"] # only used on windows
+
       labels      workerConfig["labels"]
       executors   workerConfig["executors"]
 

--- a/recipes/_worker-config-windows.rb
+++ b/recipes/_worker-config-windows.rb
@@ -37,10 +37,11 @@ node["jenkinsHomes"].each do |jenkinsHome, workerConfig|
   end
 end
 
-windows_package 'WIX' do
-  source node['wix']['url']
-  action :install
-end
+# TODO upgrade to https://wix.codeplex.com/releases/view/619491
+# windows_package 'WIX' do
+#   source node['wix']['url']
+#   action :install
+# end
 
 
 include_recipe 'scala-jenkins-infra::_worker-config-windows-cygwin'

--- a/recipes/_worker-init-windows.rb
+++ b/recipes/_worker-init-windows.rb
@@ -13,22 +13,22 @@ include_recipe 'windows'
 # hacked around by not re-installing java when javac of the right version is found
 # needed for other stuff (install ruby etc)
 
-def checkJavacVersion
-  javac = File.join(node['java']['java_home'], "bin", "javac.exe")
-  javacVersion = ""
-  if File.exists?(javac)
-    # http://stackoverflow.com/a/1666103/276895
-    IO.popen(javac+" -version 2>&1") do |pipe| # Redirection is performed using operators
-      pipe.sync = true
-      while str = pipe.gets
-        javacVersion = javacVersion + str # This is synchronous!
-      end
-    end
-  end
-  javacVersion.chop
-end
+# def checkJavacVersion
+#   javac = File.join(node['java']['java_home'], "bin", "javac.exe")
+#   javacVersion = ""
+#   if File.exists?(javac)
+#     # http://stackoverflow.com/a/1666103/276895
+#     IO.popen(javac+" -version 2>&1") do |pipe| # Redirection is performed using operators
+#       pipe.sync = true
+#       while str = pipe.gets
+#         javacVersion = javacVersion + str # This is synchronous!
+#       end
+#     end
+#   end
+#   javacVersion.chop
+# end
 
-include_recipe "java" if checkJavacVersion != node['java']['javacVersion']
+# include_recipe "java" if checkJavacVersion != node['java']['javacVersion']
 
 ruby_block 'Add Embedded Bin Path' do
   block do

--- a/recipes/master-init.rb
+++ b/recipes/master-init.rb
@@ -22,10 +22,3 @@ include_recipe "scala-jenkins-infra::_master-init-jenkins"
 
 include_recipe "scala-jenkins-infra::_master-init-artifactory"
 
-# https://github.com/scala/scala-jenkins-infra/issues/26
-if node[:ec2]
-  # workaround from https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1317811/comments/22 (until we can upgrade to kernel with fix -- >3.16.1)
-  execute 'turn off scatter-gatter' do
-    command "ethtool -K eth0 sg off"
-  end
-end

--- a/recipes/worker-config.rb
+++ b/recipes/worker-config.rb
@@ -9,7 +9,7 @@
 
 # This can only be run *after* bootstrap due to vault dependency.
 
-include_recipe "scala-jenkins-infra::_config-adminKeys"
+include_recipe "scala-jenkins-infra::_config-adminKeys" unless platform_family?("windows")
 
 node["jenkinsHomes"].each do |jenkinsHome, workerConfig|
   case node["platform_family"]

--- a/recipes/worker-init.rb
+++ b/recipes/worker-init.rb
@@ -10,9 +10,9 @@ include_recipe "scala-jenkins-infra::_config-ebs"
 
 include_recipe 'scala-jenkins-infra::_init-chef-client'
 
-include_recipe "git"
+include_recipe "git" unless platform_family?("windows")
 
-include_recipe "chef-sbt" # TODO: remove, redundant with sbt-extras, but the latter won't work on windows
+include_recipe "chef-sbt" unless platform_family?("windows")
 include_recipe "sbt-extras" unless platform_family?("windows")
 
 include_recipe "scala-jenkins-infra::_worker-init-#{node["platform_family"]}"


### PR DESCRIPTION
which requires java 8
which means we have to upgrade jenkins, as the old version couldn't handle the java upgrade

much hilarity ensued updating alternatives
the chef java recipe is a cruel joke... probably best to avoid it
