### PR TITLE
Don't store generated artifacts

### DIFF
--- a/templates/default/jobs/lampepfl/validate/partest-bootstrapped.xml.erb
+++ b/templates/default/jobs/lampepfl/validate/partest-bootstrapped.xml.erb
@@ -16,7 +16,7 @@
 %>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>hs_err_*.log,tests/partest-generated/**</artifacts>
+      <artifacts>hs_err_*.log,tests/partest-generated/gen.log</artifacts>
       <allowEmptyArchive>false</allowEmptyArchive>
       <onlyIfSuccessful>false</onlyIfSuccessful>
       <fingerprint>false</fingerprint>

--- a/templates/default/jobs/lampepfl/validate/partest.xml.erb
+++ b/templates/default/jobs/lampepfl/validate/partest.xml.erb
@@ -16,7 +16,7 @@
 %>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>hs_err_*.log,tests/partest-generated/**</artifacts>
+      <artifacts>hs_err_*.log,tests/partest-generated/gen.log</artifacts>
       <allowEmptyArchive>false</allowEmptyArchive>
       <onlyIfSuccessful>false</onlyIfSuccessful>
       <fingerprint>false</fingerprint>


### PR DESCRIPTION
Jenkins master keeps running out of inodes.
I investigated plugins to compress archives, but couldn't find one
that can be enabled selectively (don't want to risk regressions where
compression is not needed).
