### PR TITLE
checkCLA 

### DIFF
--- a/templates/default/scabot.conf.erb
+++ b/templates/default/scabot.conf.erb
@@ -10,6 +10,7 @@ scala: {
     repo:  "scala"
     branches: ["2.11.x", "2.12.x", "2.12.0"]
     lastCommitOnly: false
+    checkCLA: true
     host:  "api.github.com"
     token: "<%=@scabotVault['github']['scala']['token']%>"
   }
@@ -27,6 +28,7 @@ dotty: {
     repo:  "dotty"
     branches: ["master"]
     lastCommitOnly: true
+    checkCLA: true
     host:  "api.github.com"
     token: "<%=@scabotVault['github']['lampepfl']['token']%>"
   }


### PR DESCRIPTION
for https://github.com/scala/scabot/pull/58

note that we get a NPE if these clauses are absent:

Caused by: java.lang.NullPointerException
        at scabot.core.Configuration.configBoolean(Configuration.scala:32)
