### PR TITLE
Standardize on sbt-extras

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,10 +22,8 @@ default['repos']['caching-proxy']['jcenter']['url']      = "https://#{scalaCiHos
 
 default['s3']['downloads']['host'] = "downloads.typesafe.com.s3.amazonaws.com"
 
-# work around https://github.com/gildegoma/chef-sbt-extras/issues/33 by overriding the URL we get
-# the sbt launch script from. latest version as of 9 Sep 2015
-# sbt is used by Scabot and by the dotty build, and in some glorious future, the scala build too
-default["sbt-extras"]["download_url"] = "https://raw.githubusercontent.com/paulp/sbt-extras/968cd027dabf894bae63efd2a671aae74390d81f/sbt"
+# bumped to sbt-extras as of Oct 21 2016 (0.13.13-RC3)
+default["sbt-extras"]["download_url"] = "https://raw.githubusercontent.com/paulp/sbt-extras/ab365a8354a493fa90deabfd7884da0bed976c8b/sbt"
 
 # JAVA
 # TODO does this actually do anything???

--- a/attributes/worker.rb
+++ b/attributes/worker.rb
@@ -1,10 +1,9 @@
+default['sbt']['version'] = "0.13.12"
+
 if (node.name =~ /.*-worker-.*/) != nil
   case node["platform_family"]
   when "windows"
-
-    override['sbt']['script_name']   = 'sbt.bat'
-    override['sbt']['launcher_path'] = 'C:\sbt'
-    override['sbt']['bin_path']      = 'C:\sbt'
+    override['sbt']['launcher_path'] = 'C:\sbt\sbt-launch.jar'
 
     # this zip was reworked to have the binaries under the `bin/` directory, which is what sbt-nativepackager expects
     override['wix']['home']     = 'C:\Program Files (x86)\WiX Toolset v3.9'
@@ -63,7 +62,7 @@ if (node.name =~ /.*-worker-.*/) != nil
     default["jenkinsHomes"][jenkinsHome]["env"]         = <<-'EOH'.gsub(/^ {4}/, '')
       lambda{| node | Chef::Node::ImmutableMash.new({
         "PATH"          => "/bin:/usr/bin:/cygdrive/c/Program Files/Java/jdk1.8.0_92/bin:/cygdrive/c/Program Files (x86)/Git-2.5.3/Cmd", # TODO express in terms of attributes
-        "sbtLauncher"   => "#{node['sbt']['launcher_path']}\\sbt-launch.jar", # from chef-sbt cookbook
+        "sbtLauncher"   => node['sbt']['launcher_path'],
         "WIX"           => node['wix']['home'],
         "TMP"           => "#{node['_jenkinsTmp']}",
         "_JAVA_OPTIONS" => "-Duser.home=#{node['_jenkinsHome']}", # no other way to do this... sbt boot will fail pretty weirdly if it can't write to $HOME/.sbt and $TMP/...
@@ -75,6 +74,8 @@ if (node.name =~ /.*-worker-.*/) != nil
     # If node name contains "-publish", configure it with necessary secrets/package to roll & publish a release
     publisher = (node.name =~ /.*-publish.*/) != nil # TODO: use tag?
     lightWorker = publisher  # TODO: better heuristic...
+
+    override['sbt']['launcher_path'] = '/usr/local/lib/share/sbt-launch.jar'
 
     default['graphviz']['url']      = 'https://dl.dropboxusercontent.com/u/12862572/graphviz_2.28.0-1_amd64.deb'
     default['graphviz']['checksum'] = '76236edc36d5906b93f35e83f8f19a2045318852d3f826e920f189431967c081'
@@ -103,7 +104,7 @@ if (node.name =~ /.*-worker-.*/) != nil
     default["jenkinsHomes"]["/home/jenkins"]["env"]         = <<-'EOH'.gsub(/^ {4}/, '')
       lambda{| node | Chef::Node::ImmutableMash.new({
         "sshCharaArgs" => '("scalatest@chara.epfl.ch" "-i" "/home/jenkins/.ssh/for_chara")',
-        "sbtLauncher"  => File.join(node['sbt']['launcher_path'], "sbt-launch.jar"), # from chef-sbt cookbook
+        "sbtLauncher"  => node['sbt']['launcher_path'],
         "sbtCmd"       => File.join(node['sbt-extras']['setup_dir'], node['sbt-extras']['script_name']) # sbt-extras
       })}
       EOH

--- a/doc/staging.md
+++ b/doc/staging.md
@@ -79,7 +79,6 @@ knife cookbook site install nodejs
 
 ```
 knife cookbook github install adriaanm/jenkins/fix305  # custom fixes + https://github.com/opscode-cookbooks/jenkins/pull/313 (b-dean/jenkins/http_ca_fixes)
-knife cookbook github install adriaanm/chef-sbt
 knife cookbook github install gildegoma/chef-sbt-extras
 knife cookbook github install adriaanm/artifactory
 ```

--- a/metadata.rb
+++ b/metadata.rb
@@ -28,8 +28,6 @@ depends 'artifactory'
 depends 'git'
 depends 'git_user'
 
-# TODO remove chef-sbt dependency, but not sure sbt-extras supports windows
-depends 'chef-sbt'
 depends 'sbt-extras'
 
 depends 'runit', '~> 1.5'

--- a/recipes/worker-init.rb
+++ b/recipes/worker-init.rb
@@ -12,9 +12,20 @@ include_recipe 'scala-jenkins-infra::_init-chef-client'
 
 include_recipe "git" unless platform_family?("windows")
 
-include_recipe "chef-sbt" unless platform_family?("windows")
-include_recipe "sbt-extras" unless platform_family?("windows")
+include_recipe "sbt-extras"
 
 include_recipe "scala-jenkins-infra::_worker-init-#{node["platform_family"]}"
 
 include_recipe "scala-jenkins-infra::_jvm-select"
+
+# The bit from chef-sbt that's missing in chef-sbt-extras...
+# (Easily find the launcher jar for those paranoid jobs that want to invoke sbt using the java command
+#  could update those scripts to use sbt-extras more carefully, I suppose.)
+# TODO: remove and rework scripts
+remote_file "#{node['sbt']['launcher_path']}" do
+  source "https://repo.lightbend.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/#{node['sbt']['version']}/sbt-launch.jar"
+  action :create
+  owner "root"
+  group "root"
+  mode 0755
+end


### PR DESCRIPTION
We're still downloading the sbt-launch.jar for a couple of jobs
that rely on it being available on the file system for full control
TODO: rework those scripts to use sbt from sbt-extras

running in prod on master and ubuntu workers -- @SethTisue, could you keep an eye on the windows one?
