### PR TITLE
Parameter and notification endpoint for benchq on bootstrap

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -113,6 +113,7 @@ if node.name == "jenkins-master"
   default['master']['jenkinsHost']          = scalaCiHost
   default['master']['jenkinsUrl']           = "https://#{scalaCiHost}/"
   default['master']['jenkins']['notifyUrl'] = "http://#{scalaCiHost}:#{scabotPort}/jenkins" # scabot listens here
+  default['master']['jenkins']['benchqUrl'] = "https://scala-ci.typesafe.com/benchq/webhooks/jenkins"
 
   # NOTE: This is a string that represents a closure that closes over the worker node for which it computes the environment.
   # (by convention -- see `environment((eval node["master"]["env"])...` in _master-config-workers

--- a/libraries/job_blurbs.rb
+++ b/libraries/job_blurbs.rb
@@ -33,6 +33,21 @@ module ScalaJenkinsInfra
           <defaultValue>%{default}</defaultValue>
         </hudson.model.StringParameterDefinition>""".gsub(/        /, '')
 
+      notificationEndpoint =
+        """
+        <com.tikal.hudson.plugins.notification.Endpoint>
+          <protocol>HTTP</protocol>
+          <format>JSON</format>
+          <url>%{url}</url>
+          <event>%{event}</event>
+          <timeout>30000</timeout>
+        </com.tikal.hudson.plugins.notification.Endpoint>""".gsub(/        /, '')
+
+      notifications = [
+        {:url => node['master']['jenkins']['notifyUrl'], :event => "all"},
+        {:url => node['master']['jenkins']['benchqUrl'], :event => "all"}
+      ]
+
       paramDefaults = {:default => nil}
 
       concurr = @@concurrentDefaults.merge(concurrentOptions)
@@ -48,13 +63,7 @@ module ScalaJenkinsInfra
       """<properties>
         <com.tikal.hudson.plugins.notification.HudsonNotificationProperty plugin=\"notification@1.7\">
           <endpoints>
-            <com.tikal.hudson.plugins.notification.Endpoint>
-              <protocol>HTTP</protocol>
-              <format>JSON</format>
-              <url>#{node['master']['jenkins']['notifyUrl']}</url>
-              <event>all</event>
-              <timeout>30000</timeout>
-            </com.tikal.hudson.plugins.notification.Endpoint>
+            #{notifications.map { |notification| notificationEndpoint % notification }.join("\n")}
           </endpoints>
         </com.tikal.hudson.plugins.notification.HudsonNotificationProperty>
         <hudson.model.ParametersDefinitionProperty>

--- a/templates/default/jobs/scala/integrate/bootstrap.xml.erb
+++ b/templates/default/jobs/scala/integrate/bootstrap.xml.erb
@@ -57,7 +57,9 @@
       :desc    => "Set to anything but &quot;yes&quot; to avoid running the stability test",
       :default => "yes"},
     {:name => "publishToSonatype",
-     :desc => "Set to anything but &quot;yes&quot; to avoid publishing to sonatype. Otherwise, release builds (tagged or SCALA_VER_BASE defined) will be published."}
+     :desc => "Set to anything but &quot;yes&quot; to avoid publishing to sonatype. Otherwise, release builds (tagged or SCALA_VER_BASE defined) will be published."},
+    {:name => "benchqTaskId"
+     :desc => "For Scala builds triggered by the benchmark queue, this parameter contains the `id: Long` of the task."}
   ])
 %>
   <publishers>


### PR DESCRIPTION
The benchq tool uses the bootstrap jobs to build Scala revisions
to be benchmarked. This adds an `id` parameter and a notification
endpoint to the jobs.