### PR TITLE
Make jvmSelect function JDK 9 aware

### DIFF
--- a/files/default/jvm-select
+++ b/files/default/jvm-select
@@ -11,7 +11,7 @@ function jvmSelect(){
 
   # find first jdk home, where home is one dir up from where javac is
   for javacCmd in $eligibleCmds; do
-    if [ ! -d "$jdkHome" ] && ($javacCmd -version 2>&1 | grep "javac 1\.$jvmMajorVersion" &> /dev/null); then
+    if [ ! -d "$jdkHome" ] && ($javacCmd -version 2>&1 | egrep "javac ($jvmMajorVersion|1\.$jvmMajorVersion)\b" &> /dev/null); then
       jdkHome=$(cd $(dirname $javacCmd)/.. && pwd)
     fi
   done


### PR DESCRIPTION
See: http://openjdk.java.net/jeps/223

We could simplify the logic by changing the callers of this script
(Jenkins job parameters) from "jvmSelect oracle 8" to "jvmSelect oracle 1.8"

But for now I've retained compatibility with assuming the leading
"1."