### PR TITLE
Support publishing versions before 2.11

### DIFF
--- a/externalScripts/jobs/integrate/bootstrap
+++ b/externalScripts/jobs/integrate/bootstrap
@@ -62,7 +62,10 @@ function fReleaseTempVarName(){
 # TODO: support older revisions
 
 # main
-if containsCommit $rNewVersionFormat212 || containsCommit $rNewVersionFormat211; then
+if [ "$publishToSonatype" == "yes" ]; then # don't interfere with release builds
+  fNewVersionFormat
+
+elif containsCommit $rNewVersionFormat212 || containsCommit $rNewVersionFormat211; then
   fNewVersionFormat
 
 elif containsCommit $rReleaseTempVarName; then


### PR DESCRIPTION
We should revisit allowing external scripts that are fetched from a moving target. This further complicates reproducing older builds.